### PR TITLE
ci: auto-regenerate OG + social cards on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # `pnpm version-packages` re-renders the OG + GitHub social cards so their
+      # version pill tracks the bump (and `check:og` passes on the Version Packages
+      # PR). That render needs headless Chromium + ffmpeg. Only the version step
+      # uses these; the publish step ignores them. A transient render flake fails
+      # the job — just re-run it.
+      - name: Install card-render deps (Chromium + ffmpeg)
+        run: |
+          sudo apt-get update && sudo apt-get install -y ffmpeg
+          pnpm --filter @snapgridjs/docs exec playwright install --with-deps chromium
+
       # When changesets are present this opens/updates a "Version Packages" PR.
       # When that PR merges (versions already bumped), it runs `pnpm release`,
       # which builds and publishes the changed packages to npm.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,17 @@ snapgrid publishes three packages from this monorepo, versioned with
 
 That's the whole flow for a version bump of existing packages.
 
+### Brand cards (OG + social)
+
+The "Version Packages" PR also re-renders the social cards so their version pill tracks the bump:
+`version-packages` runs `pnpm --filter @snapgridjs/docs cards`, regenerating `apps/docs/public/og.png`
+(+ `og.version`, which the `check:og` CI guard enforces) and `media/github-social.png`. The OG card
+is site-served, so merging the PR redeploys the docs and the **live** card updates automatically.
+
+`media/github-social.png` is the one residual manual step: GitHub's repo **Settings → Social preview**
+is a web-UI upload with no API, so on a **minor/major** bump re-upload the freshly-committed file there.
+(Patch bumps keep the same `vX.Y` pill — no re-render or re-upload needed.)
+
 ## How auth works — trusted publishing (OIDC)
 
 The Release workflow publishes with **no token.** `pnpm publish` exchanges the workflow's GitHub

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,6 +18,7 @@
     "favicon": "node scripts/favicon.mjs",
     "og": "node scripts/og-image.mjs",
     "social": "node scripts/github-social.mjs",
+    "cards": "node scripts/og-image.mjs && node scripts/github-social.mjs",
     "assets": "node scripts/wordmark.mjs && node scripts/favicon.mjs && node scripts/og-image.mjs && node scripts/github-social.mjs",
     "check:og": "node scripts/check-og.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate": "pnpm typecheck && pnpm lint && pnpm test && pnpm build && pnpm size",
     "size": "size-limit",
     "changeset": "changeset",
-    "version-packages": "changeset version && pnpm --filter @snapgridjs/docs cards",
+    "version-packages": "changeset version && biome check --write packages/*/package.json && pnpm --filter @snapgridjs/docs cards",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate": "pnpm typecheck && pnpm lint && pnpm test && pnpm build && pnpm size",
     "size": "size-limit",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm --filter @snapgridjs/docs cards",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Wire the brand-card regeneration into the changesets `version` step so the OG + GitHub social cards' version pill stays in sync **automatically** on every release — no manual `pnpm assets` chore, and `check:og` stops blocking the Version Packages PR.

- `version-packages` now runs `pnpm --filter @snapgridjs/docs cards` after `changeset version`. The changesets action commits the result, so the refreshed `apps/docs/public/og.png` (+ `og.version`) and `media/github-social.png` land **inside the Version Packages PR**.
- `release.yml` installs headless Chromium + ffmpeg (the render's deps). Only the version step uses them; a transient render flake just needs a re-run.
- `RELEASING.md` documents the one residual manual step: `media/github-social.png` has no API to set it, so the repo file stays accurate but you still re-upload it to **Settings → Social preview** on a minor/major bump.

## Why

`check-og.mjs` fails CI when the committed OG card's version pill drifts from `@snapgridjs/react` — so today every minor/major release needs a manual regenerate-and-commit or the Version Packages PR can't pass `validate`. This makes the OG card fully hands-off (it's site-served, so merging redeploys the live card) and keeps the committed social card true (the upload stays manual by GitHub's design).

## Tradeoff

This puts brand-asset rendering in CI (the project previously kept it out, hence the `check:og` guard). CI Chromium can differ subtly from a local render and isn't visually diffed — mitigated by the webfont wait and by reviewing the regenerated PNGs in the Version Packages PR before merging.

Independent of the in-flight 0.2.0 release (PR #7); takes effect on the next version bump.