### PR TITLE
ci: upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,15 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      # `changeset publish` does the actual publish by shelling out to `npm`
+      # (NOT pnpm), and npm only gained OIDC trusted-publishing support in
+      # 11.5.1. The npm bundled with Node 22 is 10.9.x, which silently ignores
+      # OIDC, PUTs to the registry with no credential, and npm masks the
+      # unauthorized write to an existing scoped package as `E404 Not Found`.
+      # Pin a current npm so trusted publishing actually happens.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.16.0
+
       - run: pnpm install --frozen-lockfile
 
       # `pnpm version-packages` re-renders the OG + GitHub social cards so their

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,8 +54,14 @@ Each `@snapgridjs/*` package is configured on npmjs.com (package → **Settings*
 - **Publishing access** → _Require two-factor authentication and disallow tokens_.
 
 So the only ways to publish are this workflow (OIDC) or an interactive 2FA login from a maintainer's
-machine — there is no long-lived `NPM_TOKEN` anywhere. Requirements, already met: Node ≥ 22.14 and a
-pnpm with OIDC support (pinned here as `pnpm@10.30.3` via the root `packageManager` field).
+machine — there is no long-lived `NPM_TOKEN` anywhere.
+
+The catch: `changeset publish` runs the actual publish through **`npm`**, not pnpm, and npm only supports
+OIDC trusted publishing from **11.5.1+**. The Node 22 runner bundles npm 10.9.x, which ignores OIDC and
+publishes with no credential — npm then masks the unauthorized write as a confusing `E404 Not Found` on
+the registry `PUT`. So the workflow installs a current npm (`npm@11.16.0`) before the changesets step.
+(pnpm — pinned to `pnpm@10.30.3` via the root `packageManager` field — only runs installs and the build;
+it never does the publish.) Node ≥ 22.14 is also required.
 
 ## Manual release fallback
 


### PR DESCRIPTION
## Why

The Release workflow's publish step has been failing with:

```
E404 Not Found - PUT https://registry.npmjs.org/@snapgridjs%2freact
```

Root cause is the **npm CLI version on the runner**, not the trusted-publisher config:

- `changeset publish` does the actual publish by shelling out to **`npm`** (not pnpm) — the error output is all `npm error` / `npm notice`.
- The Node 22 runner ships **npm 10.9.8**; npm only gained OIDC trusted-publishing support in **11.5.1**.
- So npm 10.9.x ignored OIDC, PUT to the registry with no credential, and npm masked the unauthorized write to the already-existing `@snapgridjs/react` as a confusing `E404 Not Found`.

(Same issue documented in [community#173102](https://github.com/orgs/community/discussions/173102).)

## Change

- Install `npm@11.16.0` before the changesets step so trusted publishing actually happens.
- Correct `RELEASING.md`, which wrongly assumed pnpm does the publishing.

## Effect

Merging this is a push to `main` → triggers `release.yml` → no changesets pending → publish path → with npm 11.16.0 OIDC works → `@snapgridjs/react@0.2.0` publishes with provenance and its tag + GitHub release are created.