### PR TITLE
ci: use PAT for changesets so Version Packages PR triggers CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Use a PAT (not the default GITHUB_TOKEN) so the commits the changesets
+          # action pushes to the "Version Packages" PR trigger CI. GitHub suppresses
+          # workflow runs for pushes/PRs made with GITHUB_TOKEN, which is why that
+          # PR's required `validate` check never ran on its own. See RELEASING.md.
+          token: ${{ secrets.CHANGESETS_TOKEN }}
 
       - uses: pnpm/action-setup@v4
 
@@ -51,17 +57,20 @@ jobs:
       # When that PR merges (versions already bumped), it runs `pnpm release`,
       # which builds and publishes the changed packages to npm.
       #
-      # Auth is npm trusted publishing (OIDC): pnpm exchanges the job's id-token
-      # (permissions.id-token: write) for a short-lived credential, so there is
-      # NO NPM_TOKEN. Each @snapgridjs/* package has a trusted publisher set for
-      # this repo + workflow (with "disallow tokens" publishing access). See
-      # RELEASING.md.
+      # Auth is npm trusted publishing (OIDC): npm (≥11.5.1, installed above)
+      # exchanges the job's id-token (permissions.id-token: write) for a
+      # short-lived credential, so there is NO NPM_TOKEN. Each @snapgridjs/*
+      # package has a trusted publisher set for this repo + workflow (with
+      # "disallow tokens" publishing access). See RELEASING.md.
+      #
+      # GITHUB_TOKEN here is the PAT (CHANGESETS_TOKEN) so the Version Packages
+      # PR is opened by the PAT identity and its CI runs — see the checkout note.
       - name: Create Release PR or publish
         uses: changesets/action@v1
         with:
           publish: pnpm release
           version: pnpm version-packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
           # No NPM_TOKEN — npm auth is via OIDC trusted publishing (see above).
           NPM_CONFIG_PROVENANCE: "true"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,19 @@ snapgrid publishes three packages from this monorepo, versioned with
 
 That's the whole flow for a version bump of existing packages.
 
+### CI on the Version Packages PR (the `CHANGESETS_TOKEN` PAT)
+
+The changesets action authenticates with a **Personal Access Token** stored as the repo secret
+`CHANGESETS_TOKEN`, not the default `GITHUB_TOKEN`. This is deliberate: GitHub suppresses workflow runs
+for any push or PR made with `GITHUB_TOKEN`, so a Version Packages PR opened that way would never run its
+required `validate` check and could not be merged without a manual nudge. The PAT identity makes that
+PR's CI run normally.
+
+The token is a fine-grained PAT scoped to this repo with **Contents: read/write** and **Pull requests:
+read/write**. It expires — when it does, the release job fails to open/update the PR; regenerate it and
+update the secret (`gh secret set CHANGESETS_TOKEN`). npm publishing itself does **not** use this token
+(that's OIDC, below), so a missing/expired PAT blocks the version PR but never the publish.
+
 ### Brand cards (OG + social)
 
 The "Version Packages" PR also re-renders the social cards so their version pill tracks the bump:
@@ -42,8 +55,8 @@ is a web-UI upload with no API, so on a **minor/major** bump re-upload the fresh
 
 ## How auth works — trusted publishing (OIDC)
 
-The Release workflow publishes with **no token.** `pnpm publish` exchanges the workflow's GitHub
-`id-token` for a short-lived registry credential
+The Release workflow publishes with **no npm token.** `npm` (≥ 11.5.1, installed by the workflow)
+exchanges the workflow's GitHub `id-token` for a short-lived registry credential
 ([trusted publishing](https://docs.npmjs.com/trusted-publishers/)), and provenance ("Built and
 signed on GitHub Actions") is attached automatically.
 


### PR DESCRIPTION
## Why

GitHub suppresses workflow runs for any push or PR made with the default `GITHUB_TOKEN`. So the "Version Packages" PR the changesets action opens never ran its required `validate` check on its own — we had to nudge it with an empty commit each release.

## Change

- `actions/checkout` and the changesets action now authenticate with a fine-grained PAT stored as the repo secret `CHANGESETS_TOKEN` (Contents R/W + Pull requests R/W, scoped to this repo). Commits it pushes — and the PR it opens — now trigger CI normally.
- Documented the token in `RELEASING.md` (purpose, scopes, what happens when it expires).
- Fixed a stale comment/line that claimed pnpm exchanges the OIDC id-token — it's npm.

npm publishing is unaffected (that's OIDC, not this token), so a missing/expired PAT would block the version PR but never a publish.