### PR TITLE
ci: production docs track releases, not main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
       # GITHUB_TOKEN here is the PAT (CHANGESETS_TOKEN) so the Version Packages
       # PR is opened by the PAT identity and its CI runs — see the checkout note.
       - name: Create Release PR or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm release
@@ -74,3 +75,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
           # No NPM_TOKEN — npm auth is via OIDC trusted publishing (see above).
           NPM_CONFIG_PROVENANCE: "true"
+
+      # On an actual publish, fast-forward the `release` branch to this commit.
+      # Cloudflare Pages builds the PRODUCTION docs from `release` (not `main`),
+      # so the public site (snapgrid.dev) only updates when packages are
+      # released — `main` pushes deploy to a preview URL instead. This keeps the
+      # docs in lockstep with what's on npm: a feature merged to `main` but not
+      # yet released stays on preview, never the public site. Uses the
+      # PAT-authed checkout above so the push triggers Cloudflare. See RELEASING.md.
+      - name: Promote docs to production
+        if: steps.changesets.outputs.published == 'true'
+        run: git push origin HEAD:release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,7 +105,16 @@ This is what made the v0.1.0 launch a manual first publish. To add one:
    to _Require 2FA and disallow tokens_.
 3. From then on it releases through CI like the rest.
 
-## Docs deploy separately
+## Docs deploy — production tracks releases
 
-The documentation site deploys independently to **Cloudflare Pages** on every push to `main`
-(see [apps/docs/README.md](./apps/docs/README.md)). It is not part of the package release.
+The documentation site deploys to **Cloudflare Pages**, but its **production** build comes from the
+`release` branch — **not** `main`. The Release workflow fast-forwards `release` to the published commit
+only on an actual publish (the "Promote docs to production" step, gated on the `changesets`
+`published` output), so **snapgrid.dev always matches what's on npm**. A feature merged to `main` but
+not yet released shows up only on the `main` **preview** deployment, never the public site — which is
+what lets releases be batched without the docs running ahead of the package.
+
+To fix an urgent doc typo for an already-released feature without cutting a release, push the fix
+straight to `release` (it deploys to production) and also land it on `main`.
+
+See [apps/docs/README.md](./apps/docs/README.md) for the Cloudflare build settings.

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -15,11 +15,13 @@ is no server runtime.
 
 ## Deployment — Cloudflare Pages
 
-The site deploys to **Cloudflare Pages** from `main`. Project settings:
+The site deploys to **Cloudflare Pages**. Production builds from the **`release`** branch (which only
+advances when packages are published — see [RELEASING.md](../../RELEASING.md)), so the public site
+tracks what's on npm rather than `main`. Project settings:
 
 | Setting                  | Value                              |
 | ------------------------ | ---------------------------------- |
-| Production branch        | `main`                             |
+| Production branch        | `release`                          |
 | Root directory           | _(repo root — leave empty)_        |
 | Build command            | `pnpm build`                       |
 | Build output directory   | `apps/docs/out`                    |
@@ -35,5 +37,6 @@ Notes:
   Cloudflare's corepack resolves the correct version automatically.
 - Served from the `snapgrid.dev` apex, so `basePath` is empty. To host under a
   subpath instead (e.g. a project site), set `DOCS_BASE_PATH=/subpath`.
-- Pushes to `main` deploy production; pull requests get automatic preview
-  deployments.
+- Production deploys come from `release` (advanced by the Release workflow on
+  publish). Pushes to `main` and pull requests get automatic **preview**
+  deployments — so unreleased docs are previewable but never on the public site.


### PR DESCRIPTION
## Problem

Cloudflare deploys docs on every push to `main`, but npm releases are gated behind the Version Packages PR. A feature merged to `main` (e.g. pinned tiles, #12) therefore goes live on snapgrid.dev before it is published — visitors who `npm install` get an older version than the docs describe. The gap widens when releases are batched.

## Fix

Production docs build from a `release` branch instead of `main`:

- The Release workflow's new "Promote docs to production" step fast-forwards `release` to the published commit, gated on the changesets `published` output — so it advances only on an actual publish.
- `main` pushes and PRs still get Cloudflare preview deployments, so unreleased docs are previewable but never on the public site.
- Net: snapgrid.dev always matches what's on npm, and releases can be batched without the docs running ahead.

`RELEASING.md` and `apps/docs/README.md` are updated to match.

## One-time setup

- The `release` branch is created at `169b453` — the last commit whose docs match the published 0.2.0 (before the unreleased pinning).
- Cloudflare Pages → Settings → Builds & deployments → set the production branch to `release`. On save, production rebuilds from `169b453`, removing the unreleased pinning docs from the public site until 0.3.0 ships.

Merging this PR does not publish (the pending pinning changeset only refreshes the Version Packages PR), so `release` does not advance until the next release.