### PR TITLE
ci: full-history checkout so release-branch push fast-forwards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Full history so the "Promote docs to production" step can fast-forward
+          # `release` to the publish commit — a shallow clone can't prove `release`
+          # is an ancestor and the push is rejected as non-fast-forward.
+          fetch-depth: 0
           # Use a PAT (not the default GITHUB_TOKEN) so the commits the changesets
           # action pushes to the "Version Packages" PR trigger CI. GitHub suppresses
           # workflow runs for pushes/PRs made with GITHUB_TOKEN, which is why that


### PR DESCRIPTION
## Problem

The 0.3.0 publish succeeded, but the new "Promote docs to production" step failed:

```
! [rejected] HEAD -> release (fetch first)
```

`actions/checkout` defaults to a shallow clone (`fetch-depth: 1`), so the runner only has the publish commit — not its ancestors. It therefore can't prove `release` is an ancestor of HEAD, and the push is rejected as non-fast-forward.

## Fix

Set `fetch-depth: 0` on the checkout. With full history the push to `release` is a clean fast-forward.

The publish itself was unaffected; `release` was advanced manually for 0.3.0, so this only matters for future releases.