### PR TITLE
fix: clear grid placeholder when a tile is dragged out to a sortable

### DIFF
--- a/.changeset/interop-placeholder-leak.md
+++ b/.changeset/interop-placeholder-leak.md
@@ -1,0 +1,11 @@
+---
+"@snapgridjs/dnd": patch
+---
+
+Fix: a grid's landing placeholder could linger after a tile was dragged out to a foreign dnd-kit sortable
+
+When a grid tile is handed off to a `useSortable` list mid-drag, its dragged element is swapped for the
+foreign card, so the engine stops seeing a snapgrid payload and takes its external-source path. That
+path skipped hiding the source grid's placeholder, so the "where it'll land" marker could stay rendered
+in the grid while the drag was over the sortable (a dragover/dragmove race, so it surfaced
+intermittently). The source grid's placeholder is now cleared on that path too.

--- a/apps/docs/e2e/interop.spec.ts
+++ b/apps/docs/e2e/interop.spec.ts
@@ -91,6 +91,33 @@ test("grid tile → tray: pulls out into the tray, no removeChild", async ({ pag
   expect(errors, errors.join("\n")).toEqual([]);
 });
 
+test("grid tile → tray: grid placeholder clears while held over the tray", async ({ page }) => {
+  const demo = await gotoInterop(page);
+  const grid = demo.locator(".dg-grid");
+  const tile = grid.locator(":scope > .dg-cell").filter({ hasText: "chart" });
+  const card = demo.locator(".dg-tray .dg-tray__card").filter({ hasText: "users" });
+  const tb = (await tile.boundingBox())!;
+  const ub = (await card.boundingBox())!;
+
+  // Drag the tile onto a tray card and HOLD there.
+  await page.mouse.move(tb.x + tb.width / 2, tb.y + tb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(tb.x + 12, tb.y + 12, { steps: 4 });
+  await page.mouse.move(ub.x + ub.width / 2, ub.y + ub.height / 2, { steps: 14 });
+  await page.mouse.move(ub.x + ub.width / 2 + 3, ub.y + ub.height / 2, { steps: 3 });
+
+  // The tile has left the grid, so the grid's landing placeholder must not linger
+  // (regression: the engine's external-source path skipped hiding it after the
+  // dragged element swapped to a foreign sortable mid-drag).
+  let maxSeen = 0;
+  for (let i = 0; i < 6; i++) {
+    maxSeen = Math.max(maxSeen, await grid.locator(":scope > .dg-placeholder").count());
+    await page.waitForTimeout(20);
+  }
+  await page.mouse.up();
+  expect(maxSeen, "grid placeholder should not render while the tile is over the tray").toBe(0);
+});
+
 test("grid tile → tray: re-packs the hole the tile leaves (no gap)", async ({ page }) => {
   const errors = trackErrors(page);
   const demo = await gotoInterop(page);

--- a/packages/grid-dnd/src/dnd/SnapGridEngine.ts
+++ b/packages/grid-dnd/src/dnd/SnapGridEngine.ts
@@ -216,6 +216,15 @@ class SnapGridEngine {
     const destCtrl = this.#resolveDest(targetId);
 
     if (!data) {
+      // No snapgrid payload: either a true external draggable, OR a grid tile whose
+      // element was swapped for a foreign one mid-drag (interop: it became a sortable
+      // card). In the latter case the source grid still holds a "move" session from the
+      // last in-grid frame — hide its placeholder so it doesn't linger while the drag is
+      // over the foreign target. (A true external drag has no `owner`, so this is a no-op.)
+      if (owner) {
+        const cur = owner.getSession();
+        if (cur?.placeholder) owner.setSession(hideActive(cur));
+      }
       // External (non-grid) draggable: preview where it would land over a grid that accepts it.
       this.#setDest(destCtrl ? this.#receiveExternalInto(destCtrl, source, pointer) : null);
       return;


### PR DESCRIPTION
## What

When a grid tile is dragged out to a foreign dnd-kit `useSortable` list, the grid's landing placeholder (the "where it'll land" marker) could stay rendered in the grid while the drag was held over the sortable.

## Why

Once a tile is handed off to a sortable mid-drag, its dragged element is swapped for the foreign card, so the engine stops seeing a snapgrid payload and takes its external-source path in `#move`. That path returned early without hiding the source grid's session, while the placeholder-clearing (`hideActive`) lived only on the in-grid `move` path. Whether it leaked depended on the dragover/dragmove ordering on the crossing frame — so it surfaced intermittently. The external-source path now clears the source grid's placeholder too (a no-op for a true external draggable, which has no source grid).

## Validation

`pnpm validate` (typecheck + lint + test + build + size) green; `pnpm e2e` 27/27, including a new regression — `grid tile → tray: grid placeholder clears while held over the tray` (reproduced the leak 6/6 before the fix, 0/6 after). External-drop / cross-grid / nested unaffected. Changeset: `patch` (lockstep), 0.6.0 → 0.6.1.