### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -45,11 +45,11 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history so the "Promote docs to production" step can fast-forward
           # `release` to the publish commit — a shallow clone can't prove `release`
@@ -28,9 +28,9 @@ jobs:
           # PR's required `validate` check never ran on its own. See RELEASING.md.
           token: ${{ secrets.CHANGESETS_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## What

Bump the workflow actions in `ci.yml` and `release.yml`:

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v4 → v6

## Why

GitHub is removing the Node 20 runtime: Node 20 actions are forced to Node 24 on **2026-06-16** and removed from runners on 2026-09-16. All three actions ran on Node 20 at v4 and produced a deprecation annotation on every CI/Release run. The latest majors all run on `node24`.

`pnpm/action-setup@v6` keeps `version` optional, so it still reads `packageManager` from the root `package.json` (the double-pin fix that avoids `ERR_PNPM_BAD_PM_VERSION` stays intact — `version` is left unset). `node-version: 22` is unchanged; that's the build/runtime Node, independent of the action's own runtime.

## Validation

CI-only change (ships nothing), so no changeset. Validated by this PR's `validate` + `e2e` runs going green on the new action versions.