### PR TITLE
feat(docs): richer structured data and result-preview metadata

### DIFF
--- a/apps/docs/app/(site)/[[...mdxPath]]/page.tsx
+++ b/apps/docs/app/(site)/[[...mdxPath]]/page.tsx
@@ -1,3 +1,5 @@
+import { statSync } from "node:fs";
+import { join } from "node:path";
 import { VERSION } from "@/components/generated/version";
 import { DESCRIPTION, GITHUB, HOME_TITLE, SITE, pageMetadata } from "@/lib/site";
 import { useMDXComponents as getMDXComponents } from "@/mdx-components";
@@ -73,6 +75,34 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   });
 }
 
+// Stable @id anchors so the Organization/WebSite nodes can be referenced (rather
+// than re-stated) from the SoftwareApplication and per-page TechArticle nodes.
+const ORG_ID = `${SITE}/#organization`;
+const SITE_ID = `${SITE}/#website`;
+
+// Brand entity — feeds the knowledge graph and ties the social `sameAs` links to
+// the name. Uses the 180×180 PNG as the logo (SVG logos aren't eligible).
+const organization = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": ORG_ID,
+  name: "snapgrid",
+  url: `${SITE}/`,
+  logo: `${SITE}/apple-touch-icon.png`,
+  sameAs: [GITHUB],
+};
+
+// Site entity — lets per-page articles declare `isPartOf` the site.
+const webSite = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": SITE_ID,
+  name: "snapgrid",
+  url: `${SITE}/`,
+  description: DESCRIPTION,
+  publisher: { "@id": ORG_ID },
+};
+
 // SoftwareApplication JSON-LD for the homepage.
 const softwareApplication = {
   "@context": "https://schema.org",
@@ -85,8 +115,47 @@ const softwareApplication = {
   softwareVersion: VERSION,
   license: "https://opensource.org/licenses/MIT",
   sameAs: [GITHUB],
+  publisher: { "@id": ORG_ID },
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
 };
+
+// Content file mtime (YYYY-MM-DD) for a route's `dateModified`, mirroring how
+// scripts/seo.mjs stamps the sitemap. Best-effort: any miss just omits the date.
+const CONTENT_DIR = join(process.cwd(), "content");
+function lastModified(mdxPath: string[]): string | undefined {
+  const rel = mdxPath.join("/");
+  for (const candidate of [`${rel}.mdx`, `${rel}.md`, `${rel}/index.mdx`, `${rel}/index.md`]) {
+    try {
+      return statSync(join(CONTENT_DIR, candidate)).mtime.toISOString().slice(0, 10);
+    } catch {
+      // try the next candidate
+    }
+  }
+  return undefined;
+}
+
+// TechArticle for docs pages — makes them eligible for richer documentation
+// results, with a freshness signal and links back to the site/brand entities.
+function buildArticle(
+  mdxPath: string[],
+  metadata: { title?: unknown; description?: unknown },
+): object | null {
+  if (mdxPath[0] !== "docs") return null;
+  const canonical = `${SITE}${routePath(mdxPath)}/`;
+  const modified = lastModified(mdxPath);
+  const description = typeof metadata.description === "string" ? metadata.description : DESCRIPTION;
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: titleOf(metadata) || "snapgrid documentation",
+    description,
+    url: canonical,
+    inLanguage: "en",
+    isPartOf: { "@id": SITE_ID },
+    publisher: { "@id": ORG_ID },
+    ...(modified ? { dateModified: modified } : {}),
+  };
+}
 
 // BreadcrumbList for docs pages: snapgrid › Documentation › [API ›] Page.
 function buildBreadcrumb(mdxPath: string[], metadata: { title?: unknown }): object | null {
@@ -123,17 +192,25 @@ export default async function Page(props: PageProps) {
   const params = await props.params;
   const mdxPath = cleanSegments(params.mdxPath ?? []);
   const { default: MDXContent, toc, metadata, sourceCode } = await loadPage(mdxPath);
-  const jsonLd = mdxPath.length === 0 ? softwareApplication : buildBreadcrumb(mdxPath, metadata);
+  // Homepage: SoftwareApplication + the brand/site entities. Docs pages: the
+  // TechArticle and its breadcrumb. Emitted as separate <script> blocks (Google
+  // reads each independently); `@id` refs tie the article back to site/org.
+  const jsonLd =
+    mdxPath.length === 0
+      ? [softwareApplication, webSite, organization]
+      : [buildArticle(mdxPath, metadata), buildBreadcrumb(mdxPath, metadata)].filter(Boolean);
 
   return (
     <Wrapper toc={toc} metadata={metadata} sourceCode={sourceCode}>
-      {jsonLd ? (
+      {jsonLd.map((node, i) => (
         <script
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-order JSON-LD list, never reordered.
+          key={i}
           type="application/ld+json"
           // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD from our own constants + page path/title, not user input.
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(node) }}
         />
-      ) : null}
+      ))}
       <MDXContent {...props} params={{ mdxPath }} />
     </Wrapper>
   );

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -16,6 +16,15 @@ export const metadata: Metadata = {
   applicationName: "snapgrid",
   appleWebApp: { title: "snapgrid" },
   manifest: "/site.webmanifest",
+  // Default to indexable, and opt into large image previews + untruncated text
+  // snippets in results (pure upside; the 404 overrides this to noindex).
+  robots: {
+    index: true,
+    follow: true,
+    "max-image-preview": "large",
+    "max-snippet": -1,
+    "max-video-preview": -1,
+  },
   icons: {
     icon: [
       { url: "/favicon.svg", type: "image/svg+xml" },

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -10,7 +10,9 @@ export const OG_IMAGE = "/og.png";
 export const OG_ALT = "snapgrid: draggable grid layouts that drag between grids";
 // Declared once so the OG/Twitter image (with alt) stays consistent across the
 // layout defaults, per-page metadata, and the homepage.
-export const OG_IMAGES = [{ url: OG_IMAGE, width: 1200, height: 630, alt: OG_ALT }];
+export const OG_IMAGES = [
+  { url: OG_IMAGE, width: 1200, height: 630, alt: OG_ALT, type: "image/png" },
+];
 export const TWITTER_IMAGES = [{ url: OG_IMAGE, alt: OG_ALT }];
 // Keyword-rich homepage title (also the layout's `title.default`).
 export const HOME_TITLE = "snapgrid — react-grid-layout alternative on dnd-kit";


### PR DESCRIPTION
## What

- Add `Organization` and `WebSite` JSON-LD to the homepage, referenced by `@id` from the existing `SoftwareApplication` node (`publisher`).
- Emit a per-page `TechArticle` node on every `docs/*` page, carrying its own description, an `isPartOf`/`publisher` link to the site/brand entities, and a `dateModified` freshness signal derived from the content file's mtime (mirroring how `scripts/seo.mjs` stamps the sitemap).
- Opt into large image previews and untruncated snippets site-wide via a root `robots` directive (`max-image-preview:large`, `max-snippet:-1`); the 404 still overrides to `noindex`.
- Declare `og:image:type` on the social card.

## Why

The docs site already had strong per-page titles/descriptions, canonicals, OG/Twitter cards, and a generated sitemap/robots/manifest. These additions fill the remaining structured-data gaps: brand/site entities feed the knowledge graph and tie the `sameAs` links to the name, `TechArticle` makes the docs eligible for richer documentation results with a freshness date, and the robots preview directives are pure upside in how results render.

## Validation

- `pnpm validate` (typecheck + lint + test + build + size) green.
- `pnpm --filter @snapgridjs/docs e2e` — 21/21 pass.
- Verified the rendered static export: homepage emits `SoftwareApplication` + `WebSite` + `Organization`; docs pages emit `TechArticle` (with `dateModified`) + `BreadcrumbList`; `robots` and `og:image:type` tags present; 404 remains `noindex`.

Docs-app only (`@snapgridjs/docs` is private, publishes nothing) — no changeset.