### PR TITLE
feat: nested non-grid drop zones win depth precedence

### DIFF
--- a/.changeset/nested-drop-zones.md
+++ b/.changeset/nested-drop-zones.md
@@ -1,0 +1,6 @@
+---
+"@snapgridjs/dnd": minor
+"@snapgridjs/react": minor
+---
+
+Nested non-grid drop zones can now win collision precedence over the grid they sit inside. A plain `useDroppable` placed in a grid tile — a trash slot, an archive panel, a sub-list — opts into snapgrid's depth ranking by passing the new `nestedDropCollisionDetector` and marking its element with `SNAPGRID_DROPPABLE_ATTR` (`data-snapgrid-droppable`). Depth counts every marked boundary, not just grids, so arbitrary nesting resolves innermost-first — a drop zone inside a drop zone outranks its parent, the same rule that ranks an inner grid above its outer one. When the zone wins, the grid backs off (no placeholder, layout untouched — its engine reverts the tile) and you handle the drop on the shared `DragDropProvider`.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -6,12 +6,12 @@
       "packages/grid-dnd/dist/index.mjs",
       "packages/grid-core/dist/index.mjs"
     ],
-    "limit": "17.5 kB"
+    "limit": "17.9 kB"
   },
   {
     "name": "@snapgridjs/dnd (brotli)",
     "path": "packages/grid-dnd/dist/index.mjs",
-    "limit": "7.5 kB"
+    "limit": "7.9 kB"
   },
   {
     "name": "@snapgridjs/core (brotli)",

--- a/apps/docs/components/demos.tsx
+++ b/apps/docs/components/demos.tsx
@@ -13,10 +13,13 @@ import {
   type ResponsiveLayouts,
   SnapGridGroup,
   horizontalCompactor,
+  insertItemWithCompactor,
+  nestedDropCollisionDetector,
   noCompactor,
   removeItemWithCompactor,
   snapMove,
   useContainerWidth,
+  useDroppable,
   useGridContainer,
   useGridItem,
   useGridPlaceholder,
@@ -1041,6 +1044,176 @@ function NestedInner({
         options={{ gridConfig: NESTED_INNER_GRID, isResizable: false }}
         renderContent={(it) => <div className="dg-nest__tile">{it.i}</div>}
       />
+    </div>
+  );
+}
+
+/* ── Nested drop zone (a non-grid droppable inside a grid) ───────────────── */
+// A grid whose right-hand "Archive" panel is a plain dnd-kit useDroppable — NOT
+// a grid. It opts into snapgrid's depth ranking (nestedDropCollisionDetector +
+// the data-snapgrid-droppable marker), so a tile dragged over it resolves to the
+// zone, not the grid underneath: the grid backs off (no placeholder, and it
+// reverts the tile) and the zone lights up. The drop is handled by the consumer's
+// own onDragEnd — here it archives the tile (removes it from the grid, re-packing
+// the hole) and shows it as a chip you can click to restore.
+const DROPZONE_INIT: Layout = [
+  { i: "a", x: 0, y: 0, w: 4, h: 2 },
+  { i: "b", x: 4, y: 0, w: 4, h: 2 },
+  { i: "c", x: 0, y: 2, w: 4, h: 2 },
+  { i: "d", x: 4, y: 2, w: 4, h: 2 },
+  // The panel that hosts the drop zone: static, so it never drags — grabbing it
+  // (or anything in it) doesn't move a tile.
+  { i: "archive", x: 8, y: 0, w: 4, h: 4, static: true },
+];
+const ARCHIVE_ZONE_ID = "archive-zone";
+
+export function NestedDropZoneDemo() {
+  const { width, containerRef } = useContainerWidth({ initialWidth: STAGE_WIDTH });
+  const [layout, setLayout] = useState<Layout>(DROPZONE_INIT);
+  const [archived, setArchived] = useState<string[]>([]);
+
+  // Restore an archived tile: drop it back into the grid (re-packing) and remove
+  // its chip. All the demo's tiles are 4×2, so restore at that size.
+  const restore = (id: string) => {
+    setLayout((g) =>
+      insertItemWithCompactor(g, { i: id, x: 0, y: 0, w: 4, h: 2 }, 0, 0, {
+        compactor: verticalCompactor,
+        cols: GRID.cols,
+      }),
+    );
+    setArchived((a) => a.filter((x) => x !== id));
+  };
+
+  return (
+    <DemoFrame
+      title="Drop zone inside a grid"
+      hint="drag a tile onto the Archive panel — the nested drop zone wins over the grid"
+    >
+      <div ref={containerRef}>
+        <DragDropProvider
+          onDragEnd={(event) => {
+            // The zone won the collision, so it's the resolved target; the grid
+            // reverted the tile. We archive it: pull it out of the grid (re-packing
+            // the hole a plain filter would leave) and add its chip.
+            const { source, target } = event.operation;
+            if (target?.id === ARCHIVE_ZONE_ID && source?.type === "grid-item") {
+              const id = String(source.id);
+              setLayout((g) =>
+                removeItemWithCompactor(g, id, { compactor: verticalCompactor, cols: GRID.cols }),
+              );
+              setArchived((a) => (a.includes(id) ? a : [...a, id]));
+            }
+          }}
+        >
+          <HeadlessGridHost
+            layout={layout}
+            width={width}
+            onLayoutChange={setLayout}
+            options={{ gridConfig: GRID, isResizable: false }}
+            renderTile={(it, group) =>
+              it.i === "archive" ? (
+                <ArchivePanelTile
+                  key={it.i}
+                  id={it.i}
+                  group={group}
+                  archived={archived}
+                  onRestore={restore}
+                />
+              ) : null
+            }
+          />
+        </DragDropProvider>
+      </div>
+    </DemoFrame>
+  );
+}
+
+// The static grid tile that hosts the (non-grid) Archive drop zone.
+function ArchivePanelTile({
+  id,
+  group,
+  archived,
+  onRestore,
+}: {
+  id: string;
+  group: string;
+  archived: string[];
+  onRestore: (id: string) => void;
+}) {
+  const { ref, style } = useGridItem({ id, group });
+  return (
+    <div ref={ref} style={style} className="dg-cell">
+      <ArchiveZone archived={archived} onRestore={onRestore} />
+    </div>
+  );
+}
+
+// The nested drop zone: a plain useDroppable that outranks the grid it sits in.
+// The collision detector is what makes it win; the marker attribute is only for
+// droppables you'd nest INSIDE it (harmless here, and future-proofs nesting).
+function ArchiveZone({
+  archived,
+  onRestore,
+}: {
+  archived: string[];
+  onRestore: (id: string) => void;
+}) {
+  const { ref, isDropTarget } = useDroppable({
+    id: ARCHIVE_ZONE_ID,
+    accept: (s) => s.type === "grid-item",
+    collisionDetector: nestedDropCollisionDetector,
+  });
+  return (
+    <div
+      ref={ref}
+      data-snapgrid-droppable=""
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 8,
+        textAlign: "center",
+        borderRadius: 10,
+        border: `2px dashed ${isDropTarget ? "var(--dg-accent)" : "var(--dg-line-strong)"}`,
+        background: isDropTarget ? "var(--dg-accent-soft)" : "transparent",
+        color: isDropTarget ? "var(--dg-accent)" : "var(--dg-muted)",
+        transition: "background 120ms, border-color 120ms, color 120ms",
+      }}
+    >
+      <span style={{ fontWeight: 600 }}>Archive</span>
+      <span style={{ fontSize: 12 }}>
+        {isDropTarget
+          ? "release to archive"
+          : archived.length
+            ? "click a tile to restore"
+            : "drag a tile here"}
+      </span>
+      {archived.length ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, justifyContent: "center" }}>
+          {archived.map((tileId) => (
+            <button
+              key={tileId}
+              type="button"
+              onClick={() => onRestore(tileId)}
+              style={{
+                font: "inherit",
+                fontSize: 11,
+                fontWeight: 600,
+                padding: "3px 9px",
+                borderRadius: 999,
+                cursor: "pointer",
+                color: "var(--dg-accent)",
+                background: "var(--dg-accent-soft)",
+                border: "1px solid var(--dg-accent)",
+              }}
+            >
+              {tileId.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/docs/content/docs/guides/nesting.mdx
+++ b/apps/docs/content/docs/guides/nesting.mdx
@@ -4,7 +4,7 @@ description: Put a grid inside a tile of another grid. Nested grids share one pr
 ---
 
 import { Callout } from "nextra/components";
-import { NestedDemo } from "@/components/demos";
+import { NestedDemo, NestedDropZoneDemo } from "@/components/demos";
 
 # Nested grids
 
@@ -74,6 +74,66 @@ pointer-down on an inner tile from arming the panel's own drag.
 
 A tile that crosses levels is **removed from one grid's layout and added to the other's** — wire both
 grids' `onLayoutChange`, exactly like [cross-grid dragging](/docs/guides/cross-grid) between siblings.
+
+## Nested drop zones (a non-grid droppable inside a grid)
+
+The same innermost-wins rule extends to **your own** drop targets. Put a plain dnd-kit `useDroppable` —
+a trash slot, an "archive" panel, a sub-list — inside a grid tile and, by default, it can never win: a
+grid claims a drag with a boosted collision priority, so the grid underneath always outranks a plain
+droppable sitting on top of it. To opt your drop zone into the grid's depth ranking:
+
+1. Pass **`nestedDropCollisionDetector`** to your `useDroppable`. This alone makes the zone outrank the
+   grid it sits inside — the grid is a marked ancestor, so the zone ranks one level deeper.
+2. Mark the element with **`data-snapgrid-droppable`** (or the exported `SNAPGRID_DROPPABLE_ATTR`). This
+   is only needed if you nest **another** droppable inside this zone, so that inner target counts this
+   boundary and outranks it in turn. It's harmless and future-proofs nesting, so the demo below sets it.
+
+<NestedDropZoneDemo />
+
+```tsx
+import {
+  useDroppable,
+  nestedDropCollisionDetector,
+  SNAPGRID_DROPPABLE_ATTR,
+} from "@snapgridjs/react";
+
+function ArchiveZone() {
+  const { ref, isDropTarget } = useDroppable({
+    id: "archive",
+    accept: (source) => source.type === "grid-item",
+    collisionDetector: nestedDropCollisionDetector,
+  });
+  // The detector already ranks this zone above its grid. The marker makes this a
+  // nesting boundary — only matters for droppables you nest INSIDE the zone.
+  return (
+    <div ref={ref} {...{ [SNAPGRID_DROPPABLE_ATTR]: "" }} data-drop-target={isDropTarget || undefined}>
+      Archive
+    </div>
+  );
+}
+```
+
+When the pointer is over the zone, the zone wins the collision: the **grid backs off** — it shows no
+placeholder and leaves its layout untouched (its engine treats a target it doesn't own as a revert, so
+the dragged tile stays put) — and your zone becomes the resolved target. Handle the drop yourself on the
+shared `DragDropProvider`:
+
+```tsx
+<DragDropProvider
+  onDragEnd={(event) => {
+    const { source, target } = event.operation;
+    if (target?.id === "archive" && source?.type === "grid-item") {
+      // your drop logic — the grid already reverted the tile
+    }
+  }}
+>
+```
+
+<Callout type="info">
+  Depth counts **every** marked boundary, not just grids. A drop zone nested inside another **marked**
+  drop zone outranks its parent, so arbitrary nesting resolves innermost-first — the same rule that ranks
+  an inner grid above its outer one. Mark each intermediate zone: two zones at the same depth tie.
+</Callout>
 
 ## Contain a nested grid (opt out of cross-layer)
 

--- a/packages/grid-dnd/src/dnd/__tests__/collision.test.ts
+++ b/packages/grid-dnd/src/dnd/__tests__/collision.test.ts
@@ -1,15 +1,37 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { SNAPGRID_GRID_ATTR, gridDepth } from "../collision.js";
+import {
+  SNAPGRID_DROPPABLE_ATTR,
+  SNAPGRID_GRID_ATTR,
+  gridCollisionDetector,
+  nestedDepth,
+  nestedDropCollisionDetector,
+} from "../collision.js";
 
 afterEach(() => {
   document.body.innerHTML = "";
 });
 
-describe("gridDepth", () => {
-  it("is 0 for a top-level grid (no grid ancestors)", () => {
+/**
+ * A minimal fake collision input: `pointerIntersection` (which both detectors
+ * wrap) needs only a current pointer plus a droppable `shape` that contains it,
+ * and our detectors read the droppable's `element` to measure depth.
+ */
+function fakeInput(element: Element | null, contains = true) {
+  return {
+    dragOperation: { position: { current: { x: 3, y: 4 } } },
+    droppable: {
+      id: "zone",
+      element,
+      shape: { containsPoint: () => contains, center: { x: 0, y: 0 } },
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: hand-rolled stand-in for dnd-kit's input.
+  } as any;
+}
+
+describe("nestedDepth", () => {
+  it("is 0 for a top-level surface (no marked ancestors)", () => {
     document.body.innerHTML = `<div ${SNAPGRID_GRID_ATTR}></div>`;
-    const grid = document.querySelector(`[${SNAPGRID_GRID_ATTR}]`);
-    expect(gridDepth(grid)).toBe(0);
+    expect(nestedDepth(document.querySelector(`[${SNAPGRID_GRID_ATTR}]`))).toBe(0);
   });
 
   it("counts each ancestor grid container (innermost is deepest)", () => {
@@ -23,13 +45,123 @@ describe("gridDepth", () => {
           </div>
         </div>
       </div>`;
-    expect(gridDepth(document.getElementById("outer"))).toBe(0);
-    expect(gridDepth(document.getElementById("inner"))).toBe(1);
-    expect(gridDepth(document.getElementById("innermost"))).toBe(2);
+    expect(nestedDepth(document.getElementById("outer"))).toBe(0);
+    expect(nestedDepth(document.getElementById("inner"))).toBe(1);
+    expect(nestedDepth(document.getElementById("innermost"))).toBe(2);
+  });
+
+  it("counts drop-zone markers as well as grids", () => {
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="grid">
+        <div class="tile">
+          <div ${SNAPGRID_DROPPABLE_ATTR} id="zoneA">
+            <div ${SNAPGRID_DROPPABLE_ATTR} id="zoneB"></div>
+          </div>
+        </div>
+      </div>`;
+    expect(nestedDepth(document.getElementById("grid"))).toBe(0);
+    expect(nestedDepth(document.getElementById("zoneA"))).toBe(1); // grid
+    expect(nestedDepth(document.getElementById("zoneB"))).toBe(2); // grid + zoneA
+  });
+
+  it("does not count the element's own marker — only ancestors", () => {
+    // A marker earns depth for the marked element's DESCENDANTS, not for itself,
+    // so a marked zone and a plain sibling at the same DOM level measure the same.
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="grid">
+        <div class="tile"><div ${SNAPGRID_DROPPABLE_ATTR} id="marked"></div></div>
+        <div class="tile"><div id="plain"></div></div>
+      </div>`;
+    expect(nestedDepth(document.getElementById("marked"))).toBe(1); // grid only
+    expect(nestedDepth(document.getElementById("plain"))).toBe(1); // grid only — same
   });
 
   it("returns 0 for a missing element", () => {
-    expect(gridDepth(null)).toBe(0);
-    expect(gridDepth(undefined)).toBe(0);
+    expect(nestedDepth(null)).toBe(0);
+    expect(nestedDepth(undefined)).toBe(0);
+  });
+});
+
+describe("nestedDropCollisionDetector", () => {
+  it("returns null when the pointer is not inside the drop zone", () => {
+    document.body.innerHTML = `<div ${SNAPGRID_DROPPABLE_ATTR} id="zone"></div>`;
+    const el = document.getElementById("zone");
+    expect(nestedDropCollisionDetector(fakeInput(el, /* contains */ false))).toBeNull();
+  });
+
+  it("outranks the grid it sits inside (drop zone wins)", () => {
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="grid">
+        <div class="tile"><div ${SNAPGRID_DROPPABLE_ATTR} id="zone"></div></div>
+      </div>`;
+    const gridEl = document.getElementById("grid");
+    const zoneEl = document.getElementById("zone");
+    const gridHit = gridCollisionDetector(fakeInput(gridEl));
+    const zoneHit = nestedDropCollisionDetector(fakeInput(zoneEl));
+    expect(gridHit?.priority).toBe(10); // grid at depth 0
+    expect(zoneHit?.priority).toBe(11); // zone counts the grid ancestor
+    expect(zoneHit!.priority).toBeGreaterThan(gridHit!.priority);
+  });
+
+  it("ranks a nested drop zone above its parent drop zone (innermost wins)", () => {
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="grid">
+        <div ${SNAPGRID_DROPPABLE_ATTR} id="outerZone">
+          <div ${SNAPGRID_DROPPABLE_ATTR} id="innerZone"></div>
+        </div>
+      </div>`;
+    const outer = nestedDropCollisionDetector(fakeInput(document.getElementById("outerZone")));
+    const inner = nestedDropCollisionDetector(fakeInput(document.getElementById("innerZone")));
+    expect(outer?.priority).toBe(11); // grid
+    expect(inner?.priority).toBe(12); // grid + outerZone
+  });
+
+  it("makes a leaf zone outrank its grid even without its own marker", () => {
+    // The detector alone suffices for a leaf zone: the grid is a marked ancestor,
+    // so the zone ranks one deeper (11 > 10) whether or not it carries the marker.
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="grid">
+        <div class="tile"><div id="zone"></div></div>
+      </div>`;
+    expect(nestedDropCollisionDetector(fakeInput(document.getElementById("zone")))?.priority).toBe(
+      11,
+    );
+  });
+
+  it("ties a child zone with its parent when the intermediate parent is unmarked", () => {
+    // An unmarked intermediate adds no boundary, so parent and child both count only
+    // the grid — a tie. This is why each nested boundary must carry the marker.
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="grid">
+        <div id="parent"><div ${SNAPGRID_DROPPABLE_ATTR} id="child"></div></div>
+      </div>`;
+    const parent = nestedDropCollisionDetector(fakeInput(document.getElementById("parent")));
+    const child = nestedDropCollisionDetector(fakeInput(document.getElementById("child")));
+    expect(parent?.priority).toBe(11);
+    expect(child?.priority).toBe(11); // tie — parent needs the marker to rank the child above it
+  });
+});
+
+describe("gridCollisionDetector", () => {
+  it("boosts an inner grid above its outer grid", () => {
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="outer">
+        <div class="tile"><div ${SNAPGRID_GRID_ATTR} id="inner"></div></div>
+      </div>`;
+    const outer = gridCollisionDetector(fakeInput(document.getElementById("outer")));
+    const inner = gridCollisionDetector(fakeInput(document.getElementById("inner")));
+    expect(outer?.priority).toBe(10);
+    expect(inner?.priority).toBe(11);
+  });
+
+  it("counts an enclosing drop zone too, so a grid inside one ranks deeper", () => {
+    document.body.innerHTML = `
+      <div ${SNAPGRID_GRID_ATTR} id="outer">
+        <div ${SNAPGRID_DROPPABLE_ATTR}>
+          <div ${SNAPGRID_GRID_ATTR} id="inner"></div>
+        </div>
+      </div>`;
+    // outer grid (0) < enclosing drop zone (1) < inner grid (2): strict innermost.
+    expect(gridCollisionDetector(fakeInput(document.getElementById("inner")))?.priority).toBe(12);
   });
 });

--- a/packages/grid-dnd/src/dnd/collision.ts
+++ b/packages/grid-dnd/src/dnd/collision.ts
@@ -2,58 +2,80 @@ import { type CollisionDetector, pointerIntersection } from "@dnd-kit/collision"
 import { domElement } from "./entity.js";
 
 /**
- * Marker attribute set on every grid container element. Used by {@link gridDepth}
- * to measure how deeply a grid is nested, purely from the DOM.
+ * Marker attribute set on every grid container element. Used by {@link nestedDepth}
+ * to measure how deeply a surface is nested, purely from the DOM.
  */
 export const SNAPGRID_GRID_ATTR = "data-snapgrid-grid";
 
-// Base priority for a grid droppable. Outranks a dragged tile's own sortable
-// droppable so collision inside a grid resolves to the container (RGL drives the
-// move, not dnd-kit's sortable reorder), and lets a foreign sortable resolve the
-// grid as its drop target. `gridDepth` adds to this so an inner grid outranks its
-// outer one when their rects overlap.
+/**
+ * Marker attribute a consumer sets on a **non-grid** drop zone nested inside a grid
+ * (a trash slot, a sub-list, a "drop here" panel) so {@link nestedDepth} counts it
+ * as a nesting boundary. Pair it with {@link nestedDropCollisionDetector} on the same
+ * `useDroppable` and the zone outranks the grid it sits inside — and any drop zone
+ * nested deeper outranks it in turn (innermost wins).
+ */
+export const SNAPGRID_DROPPABLE_ATTR = "data-snapgrid-droppable";
+
+// Base priority for a grid (or nested drop-zone) droppable. Outranks a dragged
+// tile's own sortable droppable so collision inside a grid resolves to the container
+// (RGL drives the move, not dnd-kit's sortable reorder), and lets a foreign sortable
+// resolve the grid as its drop target. The nesting depth below adds to this so an
+// inner surface outranks an outer one when their rects overlap.
 const GRID_COLLISION_PRIORITY = 10;
 
 /**
- * How deeply `el`'s grid is nested: the number of ancestor grid containers above
- * it. A top-level grid is 0; a grid rendered inside another grid's tile is 1; and
- * so on. DOM containment is the ground truth, so this is correct regardless of the
- * React tree shape or how priorities are assigned elsewhere.
+ * How deeply `el` is nested among snapgrid droppable surfaces: the count of ANCESTORS
+ * carrying a grid ({@link SNAPGRID_GRID_ATTR}) or drop-zone ({@link SNAPGRID_DROPPABLE_ATTR})
+ * marker. The walk starts at `el.parentElement`, so `el`'s own marker never counts for
+ * itself — a marker earns depth for its descendants. A top-level grid is 0, a surface one
+ * grid deep is 1, and so on; the deeper surface wins. DOM containment is the ground truth,
+ * independent of the React tree shape.
  */
-export function gridDepth(el: Element | null | undefined): number {
+export function nestedDepth(el: Element | null | undefined): number {
   let depth = 0;
   let node = el?.parentElement ?? null;
   while (node) {
-    if (node.hasAttribute(SNAPGRID_GRID_ATTR)) depth++;
+    if (node.hasAttribute(SNAPGRID_GRID_ATTR) || node.hasAttribute(SNAPGRID_DROPPABLE_ATTR))
+      depth++;
     node = node.parentElement;
   }
   return depth;
 }
 
 /**
- * Collision detector for grid droppables. Uses **pointer** intersection (not
- * dnd-kit's default, which is pointer-first but falls back to the dragged SHAPE
- * when the pointer leaves a droppable): a grid claims a drag only while the
- * pointer is genuinely inside it. The shape fallback was actively wrong here —
- * the grid's priority boost (below) made a large dragged tile keep winning the
- * grid via mere rect-overlap even after the pointer moved off onto a sibling
- * droppable (e.g. a sortable card beside the grid), so the tile could never
- * leave the grid for that target. Pointer-only also aligns collision with the
- * receive math, which maps the pointer (not the tile rect) to a cell.
+ * Collision detector for grid containers and consumer-owned nested drop zones alike.
+ * Uses **pointer** intersection (not dnd-kit's default, which is pointer-first but
+ * falls back to the dragged SHAPE when the pointer leaves a droppable): a surface
+ * claims a drag only while the pointer is genuinely inside it. The shape fallback was
+ * actively wrong here — the priority boost (below) made a large dragged tile keep
+ * winning a grid via mere rect-overlap even after the pointer moved off onto a sibling
+ * droppable (e.g. a sortable card beside the grid), so the tile could never leave the
+ * grid for that target. Pointer-only also aligns collision with the receive math,
+ * which maps the pointer (not the tile rect) to a cell.
  *
- * When the pointer IS inside, rank the grid above the dragged tile's own
- * sortable droppable (so an in-grid move resolves to the container, letting RGL
- * drive it — not dnd-kit's sortable reorder) and above a sibling droppable the
- * pointer also happens to be over. For nested grids whose rects overlap (the
- * pointer is over both an inner grid and its outer one), boost priority by the
- * grid's nesting depth so the **innermost** grid wins; for non-nested grids
- * depth is 0, so priority is unchanged.
+ * When the pointer IS inside, rank the surface above the dragged tile's own sortable
+ * droppable (so an in-grid move resolves to the container, letting RGL drive it — not
+ * dnd-kit's sortable reorder) and above a sibling the pointer also happens to be over,
+ * then break ties between overlapping nested surfaces by boosting priority with the
+ * nesting depth so the **innermost** wins; at depth 0 (a lone top-level grid) priority
+ * is just the base.
  */
 export const gridCollisionDetector: CollisionDetector = (input) => {
   const collision = pointerIntersection(input);
   if (!collision) return null;
   return {
     ...collision,
-    priority: GRID_COLLISION_PRIORITY + gridDepth(domElement(input.droppable)),
+    priority: GRID_COLLISION_PRIORITY + nestedDepth(domElement(input.droppable)),
   };
 };
+
+/**
+ * Collision detector for a consumer's **non-grid** drop zone nested in a grid —
+ * intentionally the SAME detector as {@link gridCollisionDetector}, exported under a name
+ * that reads right on a `useDroppable`. A zone using it already outranks its grid (the
+ * grid is a marked ancestor, so it ranks one deeper) — the zone needs no marker of its
+ * own to win. Mark it with {@link SNAPGRID_DROPPABLE_ATTR} only to rank droppables nested
+ * INSIDE it; without the marker, two zones at the same grid depth tie. When the zone wins,
+ * the grid backs off (its engine reverts a target it doesn't own).
+ */
+export const nestedDropCollisionDetector = gridCollisionDetector;

--- a/packages/grid-dnd/src/index.ts
+++ b/packages/grid-dnd/src/index.ts
@@ -44,7 +44,12 @@ export { snapMove } from "./snapMove.js";
 export type { SnapMoveContext, SnapMoveEvent } from "./snapMove.js";
 
 // dnd-kit interaction pieces a binding wires onto its droppables/draggables.
-export { SNAPGRID_GRID_ATTR, gridCollisionDetector } from "./dnd/collision.js";
+export {
+  SNAPGRID_DROPPABLE_ATTR,
+  SNAPGRID_GRID_ATTR,
+  gridCollisionDetector,
+  nestedDropCollisionDetector,
+} from "./dnd/collision.js";
 export { SnapToGrid } from "./dnd/snapToGrid.js";
 export { domElement } from "./dnd/entity.js";
 export { NO_FEEDBACK, RESIZE_HANDLE_ATTR, buildItemSensors } from "./dndShared.js";

--- a/packages/grid-react/src/index.ts
+++ b/packages/grid-react/src/index.ts
@@ -108,3 +108,7 @@ export {
 // peer dependencies, so your installed copy is the one used here.
 export { useDraggable, useDroppable } from "@dnd-kit/react";
 export { Feedback, KeyboardSensor, PointerSensor } from "@dnd-kit/dom";
+// Nest a non-grid drop zone inside a grid: pass `nestedDropCollisionDetector` to
+// your `useDroppable` and mark the element with `SNAPGRID_DROPPABLE_ATTR`, so the
+// zone outranks the grid it sits in (innermost-wins). See the nesting guide.
+export { SNAPGRID_DROPPABLE_ATTR, nestedDropCollisionDetector } from "@snapgridjs/dnd";


### PR DESCRIPTION
## What

Nested **non-grid** drop zones — a plain dnd-kit `useDroppable` inside a grid tile (a trash slot, an archive panel, a sub-list) — can now win collision precedence over the grid they sit in, extending the existing innermost-wins rule to consumer drop targets.

- New public API on `@snapgridjs/dnd` and `@snapgridjs/react`: `nestedDropCollisionDetector` and `SNAPGRID_DROPPABLE_ATTR` (`data-snapgrid-droppable`).
- Grid depth generalized: `gridDepth` → `nestedDepth`, counting both grid and drop-zone markers; `gridCollisionDetector` uses it.
- Docs: a "Nested drop zones" section in the nesting guide plus an interactive Archive-panel demo (archives a dropped tile out of the grid, restores it from a chip).

## Why

A drop zone nested inside a grid could never become the drop target: the grid claims drags with a boosted collision priority, so it always outranked a plain droppable on top of it. Consumers had no way to place their own drop target inside a grid.

Depth now counts every marked ancestor (grids and drop zones), so a zone inside a grid ranks one level deeper and wins; arbitrary nesting resolves innermost-first. When the zone wins, the grid backs off (its engine reverts a target it doesn't own) and the drop is handled on the shared `DragDropProvider`. A leaf zone wins with only the detector; the marker matters for ranking droppables nested *inside* the zone.

Backward-compatible: `nestedDepth` equals the old grid-only depth when no drop zones are marked, so existing grid-only nesting is unchanged.

## Validation

- `pnpm validate` green: typecheck, lint, test, build, size. The new public API grows the bundle, so size limits were raised (`@snapgridjs/dnd` 7.5→7.9 kB, combined 17.5→17.9 kB).
- Collision unit tests (12) pin the depth semantics: own marker not counted, a leaf zone wins without its own marker, and an unmarked intermediate zone ties with its child.
- e2e: all 21 docs specs pass, including the existing nested-grid drag tests that exercise the generalized detector.
