### PR TITLE
fix(dnd): track drag position when the page scrolls mid-drag

### DIFF
--- a/.changeset/drag-scroll-tracking.md
+++ b/.changeset/drag-scroll-tracking.md
@@ -1,0 +1,11 @@
+---
+"@snapgridjs/dnd": patch
+---
+
+Fix drag position tracking when the page scrolls mid-drag. An in-grid drag (and
+resize) derived its target cell from the pointer against the grid's position
+captured at drag start, so once the page scrolled — including dnd-kit's auto-scroll
+near a viewport edge — the target stopped following and a tile couldn't reach or drop
+at rows the scroll revealed. The engine now re-anchors to the grid's live position
+each frame and recomputes on scroll (dnd-kit emits no drag-move event while
+scrolling), matching the cross-grid receive path that already read a live rect.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -6,12 +6,12 @@
       "packages/grid-dnd/dist/index.mjs",
       "packages/grid-core/dist/index.mjs"
     ],
-    "limit": "17.9 kB"
+    "limit": "18.7 kB"
   },
   {
     "name": "@snapgridjs/dnd (brotli)",
     "path": "packages/grid-dnd/dist/index.mjs",
-    "limit": "7.9 kB"
+    "limit": "8.7 kB"
   },
   {
     "name": "@snapgridjs/core (brotli)",

--- a/apps/docs/e2e/scroll.spec.ts
+++ b/apps/docs/e2e/scroll.spec.ts
@@ -1,0 +1,75 @@
+import { type Page, expect, test } from "@playwright/test";
+
+// Regression for issue #49 — drag tracking under page scroll.
+//
+// The in-grid drag target is derived from the pointer against the grid's rect. If
+// the page scrolls mid-drag, the grid moves in the viewport but the pointer does
+// not, so the target must keep tracking — otherwise the landing placeholder freezes
+// and you can't reach (or drop at) rows the scroll reveals. dnd-kit emits no
+// `dragmove` for a scroll (it only re-runs collision), so the engine listens for
+// scroll itself and recomputes. This test drives that with `window.scrollBy` while
+// the pointer is held still.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/react/examples/");
+  await page.waitForSelector(".dg-cell");
+  await page.waitForTimeout(400);
+});
+
+// Placeholder position relative to the grid's top-left — scroll-invariant (both
+// shift together when the page scrolls), so it isolates the *target cell* rather
+// than the viewport shift.
+async function placeholderRelY(page: Page, demo: ReturnType<Page["locator"]>) {
+  const ph = await demo.locator(".dg-placeholder").boundingBox();
+  const grid = await demo.locator(".dg-grid").boundingBox();
+  return ph && grid ? ph.y - grid.y : null;
+}
+
+test("the landing placeholder tracks the grid as the page scrolls under a still pointer", async ({
+  page,
+}) => {
+  // The Compaction demo, switched to the `none` packer so placement is free — a
+  // tile dropped low stays low (vertical compaction would pull it back up and hide
+  // the effect). It's the demo whose controls include a `none` pill.
+  const demo = page.locator(".dg-demo", {
+    has: page.getByRole("button", { name: "none", exact: true }),
+  });
+  await demo.scrollIntoViewIfNeeded();
+  await demo.getByRole("button", { name: "none", exact: true }).click();
+  await page.waitForTimeout(200);
+
+  // Grab the top-left tile so there's room below for the target to travel.
+  const tile = demo.locator(".dg-cell").first();
+  const b = (await tile.boundingBox())!;
+  const fx = b.x + b.width / 2;
+  const fy = b.y + b.height / 2;
+
+  // Start a real pointer drag and clear the activation threshold; the pointer then
+  // stays put for the rest of the test.
+  await page.mouse.move(fx, fy);
+  await page.mouse.down();
+  await page.mouse.move(fx + 8, fy + 8, { steps: 4 });
+  await page.waitForTimeout(200);
+
+  const gridBefore = (await demo.locator(".dg-grid").boundingBox())!;
+  const y0 = await placeholderRelY(page, demo);
+
+  // Scroll the page WITHOUT moving the pointer. dnd-kit fires no dragmove for this;
+  // the engine's own scroll handler must recompute the target against the fresh rect.
+  await page.evaluate(() => window.scrollBy(0, 140));
+  await page.waitForTimeout(300); // let the recompute + placeholder transition settle
+
+  const gridAfter = (await demo.locator(".dg-grid").boundingBox())!;
+  const y1 = await placeholderRelY(page, demo);
+  await page.mouse.up();
+
+  // Sanity: the scroll actually moved the grid in the viewport (so the drag really
+  // was under a scrolling grid, not a no-op).
+  expect(gridBefore.y - gridAfter.y, "the page scrolled the grid up").toBeGreaterThan(80);
+
+  expect(y0, "a landing placeholder is shown while dragging").not.toBeNull();
+  expect(y1, "the placeholder is still shown after scrolling").not.toBeNull();
+  // With the bug the target freezes (y1 ≈ y0); with the fix it advances downward
+  // with the scroll. Require a clear, multi-cell advance (row pitch is 62px).
+  expect(y1! - y0!, "the target tracked the scroll").toBeGreaterThan(60);
+});

--- a/packages/grid-dnd/src/dnd/SnapGridEngine.ts
+++ b/packages/grid-dnd/src/dnd/SnapGridEngine.ts
@@ -15,7 +15,14 @@ import {
 import type { GridController } from "../controller/GridController.js";
 import { getController, getGrabOffset, setGrabOffset } from "../controller/registry.js";
 import type { SnapGridDragData } from "./dragData.js";
-import { arrowStep, classifyDrop, dragData, externalDropSpec, receiveCell } from "./dragFlow.js";
+import {
+  arrowStep,
+  classifyDrop,
+  dragData,
+  externalDropSpec,
+  receiveCell,
+  scrollAdjustedPointer,
+} from "./dragFlow.js";
 import { domElement } from "./entity.js";
 
 /**
@@ -34,8 +41,27 @@ import { domElement } from "./entity.js";
 
 type Point = { x: number; y: number };
 type DragSource = { id: string | number; type?: unknown; data?: unknown } | null;
+// The slice of a dnd-kit drag operation #move needs. Both the live operation
+// (`manager.dragOperation`) and the `dragmove` event's snapshot satisfy it.
+type DragOperationView = {
+  position: { current: Point };
+  source: DragSource;
+  target: { id: string | number } | null;
+  activatorEvent: Event | null;
+};
 
 const hasWindow = typeof window !== "undefined";
+// Capture so non-bubbling scroll events from any scrollable ancestor reach us
+// (matching how dnd-kit's own ScrollListener binds); passive since we never
+// preventDefault a scroll.
+const SCROLL_LISTENER_OPTIONS = { capture: true, passive: true } as const;
+
+/** A grid element's top-left in client (viewport) space, or null if unknown. */
+function rectOrigin(el: Element | null): Point | null {
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top };
+}
 
 function dragCtx(ctrl: GridController) {
   const cfg = ctrl.config!;
@@ -70,6 +96,13 @@ class SnapGridEngine {
   #keyboard = false;
   #dropSpec: { i: string; w: number; h: number } | null = null; // external draggable
   #dropCounter = 0;
+  // The source grid's client-rect origin at drag start. The source-owned session
+  // (in-grid move / resize) derives its target from a pointer delta against
+  // offsets captured at start; comparing this against the grid's *live* origin
+  // tells us how far it has scrolled so we can re-anchor the pointer (issue #49).
+  #sourceStartOrigin: Point | null = null;
+  // A scroll listener is bound only for the duration of a drag (see #bindScroll).
+  #scrollBound = false;
   // Per-drag cache so a continuous drag (pointer over one grid for many frames)
   // doesn't re-resolve the destination controller on every move.
   #lastTargetId: string | number | null = null;
@@ -88,18 +121,11 @@ class SnapGridEngine {
           op.source as DragSource,
           op.activatorEvent,
         );
+        // dnd-kit emits no `dragmove` while the page auto-scrolls, so listen for
+        // scroll ourselves and recompute the drag against the grid's live rect.
+        this.#bindScroll();
       }),
-      mon.addEventListener("dragmove", (event) => {
-        const op = event.operation;
-        const p = op.position.current;
-        this.#move(
-          dragData(event),
-          { x: p.x, y: p.y },
-          op.source as DragSource,
-          op.target?.id ?? null,
-          op.activatorEvent,
-        );
-      }),
+      mon.addEventListener("dragmove", (event) => this.#moveFromOperation(event.operation)),
       mon.addEventListener("dragend", (event) => {
         const op = event.operation;
         this.#end(
@@ -119,6 +145,7 @@ class SnapGridEngine {
     for (const u of this.#unsub) u();
     this.#unsub = [];
     if (hasWindow) window.removeEventListener("keydown", this.#onKeyDown, true);
+    this.#unbindScroll();
   }
 
   #reset(): void {
@@ -126,6 +153,7 @@ class SnapGridEngine {
     this.#dest = null;
     this.#keyboard = false;
     this.#dropSpec = null;
+    this.#sourceStartOrigin = null;
     this.#lastTargetId = null;
     this.#lastDest = undefined;
   }
@@ -163,6 +191,9 @@ class SnapGridEngine {
     const layout = owner.getCommitted();
     const item = layout.find((it) => it.i === data.itemId);
     if (!item) return;
+    // Snapshot the grid's viewport origin so the source-owned session can correct
+    // for scroll on every later frame (see #sourceStartOrigin / scrollAdjustedPointer).
+    this.#sourceStartOrigin = rectOrigin(owner.element);
 
     if (data.kind === "resize") {
       const rect = calcGridItemPosition(cfg.positionParams, item.x, item.y, item.w, item.h);
@@ -200,7 +231,12 @@ class SnapGridEngine {
     const ownerSession = owner?.getSession();
     if (owner && ownerSession?.kind === "resize") {
       const cfg = owner.config!;
-      const next = dragResize(ownerSession, pointer, dragCtx(owner));
+      const adjusted = scrollAdjustedPointer(
+        pointer,
+        this.#sourceStartOrigin,
+        rectOrigin(owner.element),
+      );
+      const next = dragResize(ownerSession, adjusted, dragCtx(owner));
       owner.setSession(next);
       cfg.callbacks.onResize?.(
         next.preview,
@@ -237,7 +273,12 @@ class SnapGridEngine {
       const cur = owner.getSession();
       if (!cur) return;
       const cfg = owner.config!;
-      const next = dragTo(cur, pointer, dragCtx(owner));
+      const adjusted = scrollAdjustedPointer(
+        pointer,
+        this.#sourceStartOrigin,
+        rectOrigin(owner.element),
+      );
+      const next = dragTo(cur, adjusted, dragCtx(owner));
       owner.setSession(next);
       cfg.callbacks.onDrag?.(
         next.preview,
@@ -426,7 +467,9 @@ class SnapGridEngine {
       }
     } finally {
       // Always clean up, even if a consumer callback above threw — otherwise a stale
-      // session / keyboard flag / grab offset would leak into the next drag.
+      // session / keyboard flag / grab offset / scroll listener would leak into the
+      // next drag.
+      this.#unbindScroll();
       setGrabOffset(this.#manager, null);
       source?.setKeyboard(false);
       source?.setSession(null);
@@ -434,6 +477,45 @@ class SnapGridEngine {
       this.#reset();
     }
   }
+
+  // Drive #move from a dnd-kit drag operation — shared by the `dragmove` monitor
+  // event and the scroll-driven recompute below, which pass the same object.
+  #moveFromOperation(op: DragOperationView): void {
+    const p = op.position.current;
+    this.#move(
+      dragData({ operation: op }),
+      { x: p.x, y: p.y },
+      op.source as DragSource,
+      op.target?.id ?? null,
+      op.activatorEvent ?? null,
+    );
+  }
+
+  // ── Scroll tracking ───────────────────────────────────────────────────────
+  // The page (or an ancestor) scrolling mid-drag moves the grid under a possibly
+  // still pointer, but dnd-kit emits no `dragmove` for it — it only re-runs
+  // collision. So recompute the active drag ourselves against the grid's live rect
+  // (the pointer stays put in viewport space; scrolling doesn't move it), which
+  // lets the placeholder keep advancing — e.g. auto-scrolling to the bottom (#49).
+  // Bound only for the span of a drag; dnd-kit's autoscroll scrolls at most once
+  // per frame, so a direct recompute is already frame-paced.
+  #bindScroll(): void {
+    if (!hasWindow || this.#scrollBound) return;
+    this.#scrollBound = true;
+    window.addEventListener("scroll", this.#onScroll, SCROLL_LISTENER_OPTIONS);
+  }
+
+  #unbindScroll(): void {
+    if (!hasWindow || !this.#scrollBound) return;
+    this.#scrollBound = false;
+    window.removeEventListener("scroll", this.#onScroll, SCROLL_LISTENER_OPTIONS);
+  }
+
+  #onScroll = (): void => {
+    if (this.#keyboard) return; // keyboard drags step by cell, not by pointer
+    const op = this.#manager.dragOperation;
+    if (op.status.dragging) this.#moveFromOperation(op);
+  };
 
   #onKeyDown = (e: KeyboardEvent): void => {
     if (!this.#keyboard) return;

--- a/packages/grid-dnd/src/dnd/__tests__/dragFlow.test.ts
+++ b/packages/grid-dnd/src/dnd/__tests__/dragFlow.test.ts
@@ -1,4 +1,4 @@
-import { toPositionParams } from "@snapgridjs/core";
+import { beginDrag, dragTo, noCompactor, toPositionParams } from "@snapgridjs/core";
 import { describe, expect, it } from "vitest";
 import {
   type DropState,
@@ -7,6 +7,7 @@ import {
   dragData,
   dropDestination,
   receiveCell,
+  scrollAdjustedPointer,
 } from "../dragFlow.js";
 
 const pp = toPositionParams(
@@ -149,5 +150,55 @@ describe("dropDestination (#7 keyboard is in-grid only)", () => {
     expect(dropDestination({ keyboard: false, targetId: 42, myId: "me" })).toBe("42");
     expect(dropDestination({ keyboard: false, targetId: null, myId: "me" })).toBeNull();
     expect(dropDestination({ keyboard: false, targetId: undefined, myId: "me" })).toBeNull();
+  });
+});
+
+describe("scrollAdjustedPointer (drag tracking under scroll, issue #49)", () => {
+  it("returns the pointer unchanged when the grid hasn't moved", () => {
+    const p = { x: 100, y: 120 };
+    expect(scrollAdjustedPointer(p, { x: 0, y: 0 }, { x: 0, y: 0 })).toEqual(p);
+  });
+
+  it("passes the pointer through when either grid origin is unknown", () => {
+    const p = { x: 100, y: 120 };
+    expect(scrollAdjustedPointer(p, null, { x: 0, y: 0 })).toEqual(p);
+    expect(scrollAdjustedPointer(p, { x: 0, y: 0 }, null)).toEqual(p);
+  });
+
+  it("shifts by the negative of the grid's movement (page scrolled down → grid moved up)", () => {
+    // Grid's client-rect origin went from y=0 to y=-330 (page scrolled down 330px).
+    // The pointer is physically still, but relative to the grid it is now 330px lower.
+    expect(scrollAdjustedPointer({ x: 10, y: 10 }, { x: 0, y: 0 }, { x: 0, y: -330 })).toEqual({
+      x: 10,
+      y: 340,
+    });
+  });
+});
+
+describe("in-grid drag tracks the grid as the page scrolls (issue #49)", () => {
+  // Free placement so the target cell is exactly where the pointer maps (no
+  // compaction bounce), isolating the pointer→cell math the scroll fix touches.
+  const ctx = { positionParams: pp, compactor: noCompactor, cols: 12 };
+  // Tile "a" at cell (0,0), 2×2, grabbed at its top-left; the grid's top-left sits
+  // at the viewport origin when the drag starts. Row pitch is 110px (see `pp`).
+  const itemA = { i: "a", x: 0, y: 0, w: 2, h: 2 };
+  const layout = [itemA];
+  const anchor = { item: itemA, left: 10, top: 10, pointer: { x: 10, y: 10 } };
+
+  it("freezes at the start cell when the pointer is still and scroll is ignored (the bug)", () => {
+    const session = beginDrag(layout, anchor);
+    // Raw client pointer never changes while auto-scroll reveals lower rows →
+    // the target never leaves the top row, so you cannot drop at the bottom.
+    const next = dragTo(session, { x: 10, y: 10 }, ctx);
+    expect(next.placeholder).toMatchObject({ x: 0, y: 0 });
+  });
+
+  it("advances toward the bottom when the grid scrolls up under a still pointer", () => {
+    const session = beginDrag(layout, anchor);
+    // Page scrolled down 330px → grid origin y: 0 → -330, pointer physically still.
+    const adjusted = scrollAdjustedPointer({ x: 10, y: 10 }, { x: 0, y: 0 }, { x: 0, y: -330 });
+    const next = dragTo(session, adjusted, ctx);
+    // 330px ÷ 110px row pitch = 3 rows down — now reachable.
+    expect(next.placeholder).toMatchObject({ x: 0, y: 3 });
   });
 });

--- a/packages/grid-dnd/src/dnd/dragFlow.ts
+++ b/packages/grid-dnd/src/dnd/dragFlow.ts
@@ -71,6 +71,32 @@ export function receiveCell(
 }
 
 /**
+ * Re-anchor a client-space pointer to a grid that has moved in the viewport since
+ * the drag started (the page or an ancestor scrolled). The source grid's own drag
+ * session ({@link dragTo}/{@link dragResize}) derives its target from the pointer
+ * delta against offsets snapshotted at drag start; those go stale the moment the
+ * grid scrolls, so the placeholder freezes and you can't reach rows the pointer
+ * hasn't physically moved over (the auto-scroll-to-the-bottom case, issue #49).
+ *
+ * Shifting the pointer by the negative of the grid's movement makes the delta once
+ * again measure "how far the pointer moved *relative to the grid*", so a still
+ * pointer over a scrolling grid keeps advancing. The receive path already reads a
+ * live rect each frame ({@link receiveCell}); this is the source-side analog.
+ * Returns the pointer untouched when either origin is unknown (no DOM rect yet).
+ */
+export function scrollAdjustedPointer(
+  pointer: { x: number; y: number },
+  startOrigin: { x: number; y: number } | null,
+  nowOrigin: { x: number; y: number } | null,
+): { x: number; y: number } {
+  if (!startOrigin || !nowOrigin) return pointer;
+  return {
+    x: pointer.x - (nowOrigin.x - startOrigin.x),
+    y: pointer.y - (nowOrigin.y - startOrigin.y),
+  };
+}
+
+/**
  * Map a keyboard event key to a one-cell grid step while a keyboard drag is
  * active, or null for keys snapgrid doesn't own — Enter/Space (drop) and Escape
  * (cancel) fall through to dnd-kit's KeyboardSensor.


### PR DESCRIPTION
## What

An in-grid drag (and resize) now keeps tracking the pointer when the page scrolls mid-drag. The source grid's drag target is re-anchored to the grid's live viewport rect each frame, and the engine recomputes the active drag on `scroll` — dnd-kit emits no drag-move event while (auto-)scrolling, it only re-runs collision.

## Why

The in-grid target cell was derived from the pointer against the grid's position captured *at drag start*. Once the page scrolled — including dnd-kit's default auto-scroll near a viewport edge — the grid moved under a still pointer but the cached offset didn't, so the landing placeholder froze and a tile couldn't reach or drop at rows the scroll revealed (reported in #49). Dragging *between* grids was unaffected because that path already reads a live rect each frame; this brings the source-side path in line.

## Validation

- **Unit**: new `dragFlow` tests cover the frozen-target bug vs the scroll-tracked target; full suite 189 green.
- **e2e**: new `scroll.spec.ts` drives an in-grid drag on the free-placement Compaction demo, scrolls the page under a still pointer, and asserts the placeholder tracks the grid — verified it fails on the pre-fix build and passes with it. Full e2e suite 24 green (no regression across drag/resize/cross-grid/nested/interop/keyboard/snap).
- typecheck / lint / build / size-limit green. `@snapgridjs/dnd` own code 7.85 → 8.49 kB brotli; size-limit raised to cover the scroll-tracking logic. Docs bundle-size figure is unchanged at kB granularity.

Closes #49.