### PR TITLE
feat(vue): add @snapgridjs/vue binding

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,8 @@
       "@snapgridjs/dnd",
       "@snapgridjs/react",
       "@snapgridjs/extras",
-      "@snapgridjs/svelte"
+      "@snapgridjs/svelte",
+      "@snapgridjs/vue"
     ]
   ],
   "linked": [],

--- a/.changeset/vue-binding.md
+++ b/.changeset/vue-binding.md
@@ -1,0 +1,15 @@
+---
+"@snapgridjs/vue": minor
+---
+
+Add `@snapgridjs/vue` — the Vue 3 binding, built on `@dnd-kit/vue`.
+
+Composables (`useGridContainer`, `useGridItem`, `useGridPlaceholder`, `useGridResizeHandle`,
+`useResponsiveLayout`, `useContainerWidth`) plus the turnkey `GridLayout`,
+`ResponsiveGridLayout`, `GridItem`, `GridPlaceholder` and `SnapGridGroup` components.
+Same framework-free `@snapgridjs/core` + `@snapgridjs/dnd` engine as the React and Svelte
+bindings, so a grid behaves identically whichever framework renders it: cross-grid and
+nested dragging, keyboard a11y, resize handles, external drop, pluggable packing.
+
+Requires `vue@^3.5`. Components ship as render functions (no SFC toolchain needed to
+consume or build the package).

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -24,6 +24,11 @@
     "limit": "1.6 kB"
   },
   {
+    "name": "@snapgridjs/vue (brotli)",
+    "path": "packages/grid-vue/dist/index.mjs",
+    "limit": "9 kB"
+  },
+  {
     "name": "@snapgridjs/svelte shipped source (brotli)",
     "path": ["packages/grid-svelte/dist/**/*.js", "packages/grid-svelte/dist/**/*.svelte"],
     "limit": "20 kB"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,17 +3,18 @@
 Maintainer runbook for cutting a snapgrid release. Contributors don't need this —
 see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-snapgrid publishes five packages from this monorepo, versioned with
+snapgrid publishes six packages from this monorepo, versioned with
 [Changesets](https://github.com/changesets/changesets):
 
 - `@snapgridjs/core`
 - `@snapgridjs/dnd`
 - `@snapgridjs/react`
 - `@snapgridjs/svelte`
+- `@snapgridjs/vue`
 - `@snapgridjs/extras`
 
-These five are kept in **lockstep** — they always share one version (changesets `fixed` in
-`.changeset/config.json`), dnd-kit-style. Any release bumps all five to the same number, even ones
+These six are kept in **lockstep** — they always share one version (changesets `fixed` in
+`.changeset/config.json`), dnd-kit-style. Any release bumps all six to the same number, even ones
 without changes, so "snapgrid X.Y.Z" means one matched set. (`@snapgridjs/docs` is private and never
 published — it's in the changesets `ignore` list.)
 
@@ -101,7 +102,7 @@ Local publishes do **not** carry the provenance badge — only CI (OIDC) does �
 A brand-new package can't be released by CI until it exists, because the OIDC trusted publisher is
 configured **per package** and npm enforces 2FA on writes (which CI can't satisfy interactively).
 This is what made the v0.1.0 launch a manual first publish — and `@snapgridjs/svelte` its own when it
-joined the set in the 0.8.x line. To add one:
+joined the set in the 0.8.x line, and `@snapgridjs/vue` its own when it joined. To add one:
 
 1. **Bootstrap locally** — `npm login`, then
    `pnpm --filter <new-pkg> publish --access public --no-git-checks` (enter the OTP). This creates

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.1.0",
     "@testing-library/svelte": "^5.2.6",
+    "@testing-library/vue": "^8.1.0",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -46,6 +47,7 @@
     "tsdown": "^0.22.1",
     "typescript": "^5.7.2",
     "unrun": "^0.3.0",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "vue": "^3.5.0"
   }
 }

--- a/packages/grid-vue/README.md
+++ b/packages/grid-vue/README.md
@@ -1,0 +1,120 @@
+# @snapgridjs/vue
+
+**A [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) v2 alternative, built on [dnd-kit](https://github.com/clauderic/dnd-kit) — for Vue 3.**
+
+Draggable, resizable, responsive grid layouts for Vue — with pluggable packing and dragging tiles _between_ grids.
+
+[![npm](https://img.shields.io/npm/v/@snapgridjs/vue.svg)](https://www.npmjs.com/package/@snapgridjs/vue)
+[![License: MIT](https://img.shields.io/badge/license-MIT-c2410c.svg)](https://github.com/eleung/snapgrid/blob/main/LICENSE)
+
+[**Documentation**](https://snapgrid.dev) ·
+[React docs](https://snapgrid.dev/react/docs/getting-started) ·
+[Svelte docs](https://snapgrid.dev/svelte/docs/getting-started)
+
+> The Vue binding of snapgrid. Same framework-free core + dnd-kit engine as [`@snapgridjs/react`](https://www.npmjs.com/package/@snapgridjs/react) and [`@snapgridjs/svelte`](https://www.npmjs.com/package/@snapgridjs/svelte) — a grid behaves identically whichever framework renders it.
+
+> **Vue guides are still being written.** The quick start below is complete and current. Until the Vue pages land on [snapgrid.dev](https://snapgrid.dev), the [React](https://snapgrid.dev/react/docs/getting-started) and [Svelte](https://snapgrid.dev/svelte/docs/getting-started) guides describe the same engine, options and behaviour — only the binding syntax differs.
+
+## Why snapgrid
+
+- **Controlled & predictable** — you own the layout array; every change comes back through `onLayoutChange`. No hidden state.
+- **Headless-first** — compose `useGridContainer` + composables under a dnd-kit `DragDropProvider` for full control of your markup — or drop in the turnkey `<GridLayout>` when you don't need that. Ships **no CSS**.
+- **Vue 3 native** — composables returning refs and function refs; tiles declare a `group`, like a dnd-kit sortable. Fine-grained reactivity, nothing to memoize.
+- **Pluggable packing** — `vertical` / `horizontal` / `none`, plus `masonry` / `gravity` / `shelf` from [`@snapgridjs/extras`](https://www.npmjs.com/package/@snapgridjs/extras), or your own `Compactor`.
+- **Cross-grid dragging** — wrap grids in a `<SnapGridGroup>` and drag tiles between them.
+- **Nested grids** — drop a grid inside a tile of another and drag tiles between levels; isolate a sub-grid with its own provider when you want it contained.
+- **dnd-kit interop** — drag between a grid and a dnd-kit `useSortable` list or board (cards in, tiles out, both reorder) under one provider, via `snapMove`.
+- **Responsive** — per-breakpoint layouts with `<ResponsiveGridLayout>`.
+- **SSR-safe** (Nuxt) and **TypeScript-first** (types included).
+
+## Install
+
+```sh
+pnpm add @snapgridjs/vue @dnd-kit/vue @dnd-kit/dom
+```
+
+Requires **Vue 3.5+** (`vue@^3.5`, a peer dependency). `@snapgridjs/extras` (masonry/gravity/shelf packers) is optional.
+
+## Quick start
+
+snapgrid is **headless-first**: you compose composables with a dnd-kit `DragDropProvider` and render your own markup. Vue resolves `inject` from the parent chain, so the grid host must live in a **child component** of the provider — never in the component that renders it.
+
+```vue
+<!-- Board.vue -->
+<script setup lang="ts">
+import { ref } from "vue";
+import { DragDropProvider, useContainerWidth } from "@snapgridjs/vue";
+import Surface from "./Surface.vue";
+
+const layout = ref([
+  { i: "a", x: 0, y: 0, w: 4, h: 2 },
+  { i: "b", x: 4, y: 0, w: 4, h: 2 },
+  { i: "c", x: 8, y: 0, w: 4, h: 2 },
+]);
+// Composables return refs — destructure them so the template auto-unwraps each one.
+const { width, setRef } = useContainerWidth();
+</script>
+
+<template>
+  <!-- DragDropProvider is the outermost element; Surface calls useGridContainer
+       inside it, so it resolves the provider's dnd-kit manager. -->
+  <div :ref="setRef">
+    <DragDropProvider>
+      <Surface :layout="layout" :width="width" @layout-change="layout = $event" />
+    </DragDropProvider>
+  </div>
+</template>
+```
+
+```vue
+<!-- Surface.vue — the grid host; exposes the grid's `group`. -->
+<script setup lang="ts">
+import { useGridContainer, type Layout } from "@snapgridjs/vue";
+import Tile from "./Tile.vue";
+
+const props = defineProps<{ layout: Layout; width: number }>();
+const emit = defineEmits<{ layoutChange: [Layout] }>();
+
+const { setRef, style, group } = useGridContainer(() => ({
+  layout: props.layout,
+  width: props.width,
+  onLayoutChange: (next) => emit("layoutChange", next),
+}));
+</script>
+
+<template>
+  <div :ref="setRef" :style="style">
+    <Tile v-for="it in layout" :key="it.i" :id="it.i" :group="group" />
+  </div>
+</template>
+```
+
+```vue
+<!-- Tile.vue — each tile resolves its grid by `group`, like a dnd-kit sortable. -->
+<script setup lang="ts">
+import { useGridItem } from "@snapgridjs/vue";
+
+const props = defineProps<{ id: string; group: string }>();
+const { setRef, style } = useGridItem({ id: props.id, group: props.group });
+</script>
+
+<template>
+  <div :ref="setRef" :style="style" class="tile">{{ id }}</div>
+</template>
+```
+
+**Prefer a ready-made component?** The turnkey `<GridLayout>` wraps these same composables (and supplies the provider) — pass an `item` scoped slot and you're done:
+
+```vue
+<GridLayout :layout="layout" :width="width" :on-layout-change="(next) => (layout = next)">
+  <template #item="{ item }">
+    <div class="tile">{{ item.i }}</div>
+  </template>
+</GridLayout>
+```
+
+The `item` slot receives the item's **committed** layout entry. Inside a tile, `useGridItem().item` gives the live (reflowed) entry during a drag.
+
+## License
+
+MIT © Edmond Leung

--- a/packages/grid-vue/package.json
+++ b/packages/grid-vue/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@snapgridjs/vue",
+  "version": "0.9.1",
+  "description": "Vue 3 grid-layout components built on dnd-kit — a react-grid-layout v2 alternative.",
+  "license": "MIT",
+  "author": "Edmond Leung",
+  "homepage": "https://snapgrid.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eleung/snapgrid.git",
+    "directory": "packages/grid-vue"
+  },
+  "bugs": "https://github.com/eleung/snapgrid/issues",
+  "keywords": [
+    "vue",
+    "vue3",
+    "grid",
+    "grid-layout",
+    "react-grid-layout",
+    "vue-grid-layout",
+    "drag-and-drop",
+    "draggable",
+    "resizable",
+    "responsive",
+    "dashboard",
+    "kanban",
+    "dnd-kit",
+    "snapgrid"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@snapgridjs/core": "workspace:*",
+    "@snapgridjs/dnd": "workspace:*"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0",
+    "@dnd-kit/dom": "^0.4.0",
+    "@dnd-kit/vue": "^0.4.0"
+  },
+  "devDependencies": {
+    "@dnd-kit/abstract": "^0.4.0",
+    "@dnd-kit/collision": "^0.4.0",
+    "@dnd-kit/dom": "^0.4.0",
+    "@dnd-kit/state": "^0.4.0",
+    "@dnd-kit/vue": "^0.4.0",
+    "vue": "^3.5.0"
+  }
+}

--- a/packages/grid-vue/src/__tests__/dragLifecycle.test.ts
+++ b/packages/grid-vue/src/__tests__/dragLifecycle.test.ts
@@ -1,0 +1,295 @@
+import type { Layout, LayoutItem } from "@snapgridjs/core";
+import { render } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
+import { type Board, CrossGrid, DragProvider } from "./fixtures.js";
+
+// Drives the grid's drag/resize lifecycle by dispatching synthetic operations through
+// dnd-kit's monitor (the same channel the engine binds to), so the public events
+// contract — onDragStart/onDrag/onDragStop/onResize*/onDrop and the onLayoutChange
+// commits, incl. cross-grid — is asserted without a real browser. Mirrors the React and
+// Svelte bindings' dragLifecycle tests; a shared engine, three bindings.
+
+type Monitor = { monitor: { dispatch(type: string, event: unknown): void } };
+
+type SnapGrid =
+  | { kind: "move"; itemId: string; item: LayoutItem; group: string }
+  | { kind: "resize"; itemId: string; handle: string; group: string };
+
+function gridSource(snapGrid: SnapGrid) {
+  return { id: snapGrid.itemId, data: { snapGrid } };
+}
+function externalSource(id: string, drop: { w: number; h: number }) {
+  return { id, data: { snapGridDrop: drop } };
+}
+
+function ev(opts: {
+  source?: unknown;
+  target?: string | null;
+  pointer?: { x: number; y: number };
+  canceled?: boolean;
+  activator?: Event | null;
+}) {
+  return {
+    operation: {
+      source: opts.source ?? null,
+      target: opts.target != null ? { id: opts.target } : null,
+      position: { current: opts.pointer ?? { x: 0, y: 0 } },
+      activatorEvent: opts.activator ?? null,
+    },
+    canceled: opts.canceled ?? false,
+    nativeEvent: null,
+  };
+}
+
+type Callbacks = Record<
+  | "onLayoutChange"
+  | "onDragStart"
+  | "onDrag"
+  | "onDragStop"
+  | "onResizeStart"
+  | "onResize"
+  | "onResizeStop"
+  | "onDrop",
+  ReturnType<typeof vi.fn>
+>;
+
+function makeCallbacks(): Callbacks {
+  return {
+    onLayoutChange: vi.fn(),
+    onDragStart: vi.fn(),
+    onDrag: vi.fn(),
+    onDragStop: vi.fn(),
+    onResizeStart: vi.fn(),
+    onResize: vi.fn(),
+    onResizeStop: vi.fn(),
+    onDrop: vi.fn(),
+  };
+}
+
+// The engine's monitor listeners run synchronously, and every assertion here is on a
+// callback rather than the DOM, so no scheduler flush is needed (the Svelte binding
+// wraps this in `flushSync`; Vue's scheduler is async-only and irrelevant here).
+function fire(manager: Monitor, type: string, event: unknown) {
+  manager.monitor.dispatch(type, event);
+}
+
+function firstLayout(fn: ReturnType<typeof vi.fn>): Layout {
+  const call = fn.mock.calls[0];
+  if (!call) throw new Error("expected the callback to have been called");
+  return call[0] as Layout;
+}
+
+const A: LayoutItem = { i: "a", x: 0, y: 0, w: 2, h: 2 };
+const B: LayoutItem = { i: "b", x: 2, y: 0, w: 2, h: 1 };
+
+function setupGrid(id: string, layout: Layout, extra?: Record<string, unknown>) {
+  const cb = makeCallbacks();
+  let manager!: Monitor;
+  render(DragProvider, {
+    props: {
+      id,
+      layout,
+      options: { ...cb, ...extra },
+      onManager: (m: unknown) => {
+        manager = m as Monitor;
+      },
+    },
+  });
+  return { cb, manager };
+}
+
+function setupCrossGrid() {
+  const aCb = makeCallbacks();
+  const bCb = makeCallbacks();
+  let manager!: Monitor;
+  const a: Board = { id: "A", layout: [A], options: { ...aCb } };
+  const b: Board = {
+    id: "B",
+    layout: [{ i: "x", x: 0, y: 0, w: 1, h: 1 }],
+    options: { ...bCb },
+  };
+  render(CrossGrid, {
+    props: {
+      a,
+      b,
+      onManager: (m: unknown) => {
+        manager = m as Monitor;
+      },
+    },
+  });
+  return { aCb, bCb, manager };
+}
+
+describe("drag lifecycle (events + commits via the monitor)", () => {
+  it("an in-grid move fires onDragStart → onDrag → onDragStop and commits the new layout", () => {
+    const { cb, manager } = setupGrid("g", [A, B]);
+    const move: SnapGrid = { kind: "move", itemId: "a", item: A, group: "g" };
+
+    fire(
+      manager,
+      "dragstart",
+      ev({ source: gridSource(move), target: "g", pointer: { x: 50, y: 50 } }),
+    );
+    expect(cb.onDragStart).toHaveBeenCalledTimes(1);
+
+    fire(
+      manager,
+      "dragmove",
+      ev({ source: gridSource(move), target: "g", pointer: { x: 250, y: 160 } }),
+    );
+    expect(cb.onDrag).toHaveBeenCalled();
+
+    fire(
+      manager,
+      "dragend",
+      ev({ source: gridSource(move), target: "g", pointer: { x: 250, y: 160 } }),
+    );
+    expect(cb.onDragStop).toHaveBeenCalledTimes(1);
+    expect(cb.onLayoutChange).toHaveBeenCalledTimes(1);
+
+    const next = firstLayout(cb.onLayoutChange);
+    const a = next.find((it) => it.i === "a");
+    expect(a).toBeDefined();
+    expect((a?.x ?? 0) + (a?.y ?? 0)).toBeGreaterThan(0);
+    expect(next.some((it) => it.i === "b")).toBe(true);
+  });
+
+  it("a canceled move fires onDragStop but does NOT commit a layout change", () => {
+    const { cb, manager } = setupGrid("g", [A, B]);
+    const move: SnapGrid = { kind: "move", itemId: "a", item: A, group: "g" };
+    fire(
+      manager,
+      "dragstart",
+      ev({ source: gridSource(move), target: "g", pointer: { x: 50, y: 50 } }),
+    );
+    fire(
+      manager,
+      "dragmove",
+      ev({ source: gridSource(move), target: "g", pointer: { x: 250, y: 160 } }),
+    );
+    fire(manager, "dragend", ev({ source: gridSource(move), target: "g", canceled: true }));
+
+    expect(cb.onDragStop).toHaveBeenCalledTimes(1);
+    expect(cb.onLayoutChange).not.toHaveBeenCalled();
+  });
+
+  it("a resize fires onResizeStart → onResize → onResizeStop and commits the new size", () => {
+    const { cb, manager } = setupGrid("g", [A, B]);
+    const resize: SnapGrid = { kind: "resize", itemId: "a", handle: "se", group: "g" };
+    fire(
+      manager,
+      "dragstart",
+      ev({ source: gridSource(resize), target: "g", pointer: { x: 200, y: 210 } }),
+    );
+    expect(cb.onResizeStart).toHaveBeenCalledTimes(1);
+
+    fire(
+      manager,
+      "dragmove",
+      ev({ source: gridSource(resize), target: "g", pointer: { x: 400, y: 210 } }),
+    );
+    expect(cb.onResize).toHaveBeenCalled();
+
+    fire(
+      manager,
+      "dragend",
+      ev({ source: gridSource(resize), target: "g", pointer: { x: 400, y: 210 } }),
+    );
+    expect(cb.onResizeStop).toHaveBeenCalledTimes(1);
+    expect(cb.onLayoutChange).toHaveBeenCalledTimes(1);
+    const a = firstLayout(cb.onLayoutChange).find((it) => it.i === "a");
+    expect(a?.w ?? 0).toBeGreaterThan(2);
+    expect(cb.onDragStop).not.toHaveBeenCalled();
+  });
+
+  it("an external draggable dropped in fires onDrop with the synthesized item", () => {
+    const { cb, manager } = setupGrid("g", [A], {
+      dropConfig: { enabled: true, defaultItem: { w: 1, h: 1 } },
+    });
+    const src = externalSource("palette-wide", { w: 3, h: 2 });
+    fire(manager, "dragstart", ev({ source: src, target: "g", pointer: { x: 100, y: 100 } }));
+    fire(manager, "dragmove", ev({ source: src, target: "g", pointer: { x: 100, y: 100 } }));
+    fire(manager, "dragend", ev({ source: src, target: "g", pointer: { x: 100, y: 100 } }));
+
+    expect(cb.onDrop).toHaveBeenCalledTimes(1);
+    expect(cb.onLayoutChange).not.toHaveBeenCalled();
+    const [layout, item] = cb.onDrop.mock.calls[0] as [Layout, LayoutItem];
+    expect(item).toMatchObject({ w: 3, h: 2 });
+    expect(item.i.startsWith("g-dropped-")).toBe(true);
+    expect(layout.some((it) => it.i === item.i)).toBe(true);
+  });
+
+  it("a keyboard drag steps the tile with arrow keys and commits in-grid", () => {
+    const { cb, manager } = setupGrid("g", [A, B]);
+    const move: SnapGrid = { kind: "move", itemId: "a", item: A, group: "g" };
+    const activator = new KeyboardEvent("keydown", { key: "Enter" });
+    fire(manager, "dragstart", ev({ source: gridSource(move), target: "g", activator }));
+    expect(cb.onDragStart).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    fire(manager, "dragend", ev({ source: gridSource(move), target: null }));
+
+    expect(cb.onDragStop).toHaveBeenCalledTimes(1);
+    expect(cb.onLayoutChange).toHaveBeenCalledTimes(1);
+    const a = firstLayout(cb.onLayoutChange).find((it) => it.i === "a");
+    expect(a?.x).toBe(1);
+    expect(a?.y).toBe(0);
+  });
+});
+
+describe("cross-grid hand-off (one manager, two grids)", () => {
+  it("dragging a tile from grid A into grid B removes it from A and adds it to B", () => {
+    const { aCb, bCb, manager } = setupCrossGrid();
+    const move: SnapGrid = { kind: "move", itemId: "a", item: A, group: "A" };
+
+    fire(
+      manager,
+      "dragstart",
+      ev({ source: gridSource(move), target: "A", pointer: { x: 50, y: 50 } }),
+    );
+    fire(
+      manager,
+      "dragmove",
+      ev({ source: gridSource(move), target: "B", pointer: { x: 100, y: 100 } }),
+    );
+    fire(
+      manager,
+      "dragend",
+      ev({ source: gridSource(move), target: "B", pointer: { x: 100, y: 100 } }),
+    );
+
+    expect(aCb.onDragStop).toHaveBeenCalledTimes(1);
+    expect(aCb.onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(firstLayout(aCb.onLayoutChange).some((it) => it.i === "a")).toBe(false);
+
+    expect(bCb.onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(firstLayout(bCb.onLayoutChange).some((it) => it.i === "a")).toBe(true);
+    expect(bCb.onDragStop).not.toHaveBeenCalled();
+  });
+
+  it("a drop whose end-target differs from the previewed grid still lands there", () => {
+    const { aCb, bCb, manager } = setupCrossGrid();
+    const move: SnapGrid = { kind: "move", itemId: "a", item: A, group: "A" };
+
+    fire(
+      manager,
+      "dragstart",
+      ev({ source: gridSource(move), target: "A", pointer: { x: 50, y: 50 } }),
+    );
+    fire(
+      manager,
+      "dragmove",
+      ev({ source: gridSource(move), target: "B", pointer: { x: 100, y: 100 } }),
+    );
+    fire(
+      manager,
+      "dragend",
+      ev({ source: gridSource(move), target: "C", pointer: { x: 100, y: 100 } }),
+    );
+
+    expect(aCb.onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(firstLayout(aCb.onLayoutChange).some((it) => it.i === "a")).toBe(false);
+    expect(bCb.onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(firstLayout(bCb.onLayoutChange).some((it) => it.i === "a")).toBe(true);
+  });
+});

--- a/packages/grid-vue/src/__tests__/fixtures.ts
+++ b/packages/grid-vue/src/__tests__/fixtures.ts
@@ -1,0 +1,257 @@
+import { DragDropProvider, useDragDropManager } from "@dnd-kit/vue";
+import type { GridConfig, Layout, LayoutItem, ResponsiveLayouts } from "@snapgridjs/core";
+import { type PropType, defineComponent, h } from "vue";
+import {
+  GridLayout,
+  ResponsiveGridLayout,
+  SnapGridGroup,
+  type UseGridControllerOptions,
+  useGridContainer,
+  useGridItem,
+} from "../index.js";
+
+// Vue test fixtures, authored as `defineComponent` render functions to match how the
+// package itself is written (no SFC toolchain in this package).
+
+const SMALL_GRID: Partial<GridConfig> = {
+  cols: 4,
+  rowHeight: 100,
+  margin: [10, 10],
+  containerPadding: [0, 0],
+};
+
+const layoutProp = { type: Array as PropType<Layout>, required: true as const };
+
+/** A turnkey <GridLayout> rendering one div per item. */
+export const Grid = defineComponent({
+  props: {
+    layout: layoutProp,
+    width: { type: Number, default: 400 },
+    gridConfig: { type: Object as PropType<Partial<GridConfig>>, default: () => SMALL_GRID },
+    isResizable: { type: Boolean, default: true },
+    isDraggable: { type: Boolean, default: true },
+  },
+  setup(props) {
+    return () =>
+      h(
+        GridLayout,
+        {
+          layout: props.layout,
+          width: props.width,
+          gridConfig: props.gridConfig,
+          isResizable: props.isResizable,
+          isDraggable: props.isDraggable,
+        },
+        { item: ({ item }: { item: LayoutItem }) => h("div", { class: "content" }, item.i) },
+      );
+  },
+});
+
+/** A headless tile built from `useGridItem`. */
+const Tile = defineComponent({
+  props: { id: { type: String, required: true }, group: { type: String, required: true } },
+  setup(props) {
+    const tile = useGridItem({ id: props.id, group: props.group });
+    return () =>
+      h(
+        "div",
+        {
+          class: "headless-tile",
+          "data-grid-id": props.id,
+          ref: tile.setRef,
+          style: tile.style.value,
+        },
+        props.id,
+      );
+  },
+});
+
+/** A headless surface built from `useGridContainer`. Must live under the provider. */
+const HeadlessContainer = defineComponent({
+  props: { layout: layoutProp, width: { type: Number, required: true } },
+  setup(props) {
+    const container = useGridContainer(() => ({
+      layout: props.layout,
+      width: props.width,
+      gridConfig: SMALL_GRID,
+    }));
+    return () =>
+      h(
+        "div",
+        {
+          class: "headless-surface",
+          "data-group": container.group.value,
+          ref: container.setRef,
+          style: container.style.value,
+        },
+        props.layout.map((it) => h(Tile, { key: it.i, id: it.i, group: container.group.value })),
+      );
+  },
+});
+
+export const Headless = defineComponent({
+  props: { layout: layoutProp, width: { type: Number, default: 400 } },
+  setup(props) {
+    return () =>
+      h(DragDropProvider, null, {
+        default: () => h(HeadlessContainer, { layout: props.layout, width: props.width }),
+      });
+  },
+});
+
+/**
+ * A nested grid hosted inside an outer tile: the inner grid must NOT mint a second
+ * dnd-kit manager (it shares the outer provider). If dedupe were broken, the inner tiles
+ * would throw "no grid found".
+ */
+export const Nested = defineComponent({
+  props: { outer: layoutProp, inner: layoutProp },
+  setup(props) {
+    return () =>
+      h(
+        GridLayout,
+        { id: "outer", layout: props.outer, width: 400, gridConfig: SMALL_GRID },
+        {
+          item: ({ item }: { item: LayoutItem }) =>
+            item.i === "host"
+              ? h(
+                  GridLayout,
+                  { id: "inner", layout: props.inner, width: 180, gridConfig: SMALL_GRID },
+                  {
+                    item: ({ item: innerItem }: { item: LayoutItem }) =>
+                      h("div", { class: "inner-content" }, innerItem.i),
+                  },
+                )
+              : h("div", { class: "outer-content" }, item.i),
+        },
+      );
+  },
+});
+
+/** Two sibling grids sharing one provider so tiles can cross between them. */
+export const Siblings = defineComponent({
+  props: { left: layoutProp, right: layoutProp },
+  setup(props) {
+    const slot = (cls: string) => ({
+      item: ({ item }: { item: LayoutItem }) => h("div", { class: cls }, item.i),
+    });
+    return () =>
+      h(SnapGridGroup, null, {
+        default: () => [
+          h(
+            GridLayout,
+            { id: "left", layout: props.left, width: 400, gridConfig: SMALL_GRID },
+            slot("left-content"),
+          ),
+          h(
+            GridLayout,
+            { id: "right", layout: props.right, width: 400, gridConfig: SMALL_GRID },
+            slot("right-content"),
+          ),
+        ],
+      });
+  },
+});
+
+export const Responsive = defineComponent({
+  props: {
+    width: { type: Number, required: true },
+    layouts: { type: Object as PropType<ResponsiveLayouts>, required: true },
+    onBreakpointChange: Function as PropType<(breakpoint: string, cols: number) => void>,
+  },
+  setup(props) {
+    return () =>
+      h(
+        ResponsiveGridLayout,
+        {
+          width: props.width,
+          layouts: props.layouts,
+          onBreakpointChange: props.onBreakpointChange,
+          rowHeight: 100,
+          margin: [10, 10],
+        },
+        { item: ({ item }: { item: LayoutItem }) => h("div", { class: "content" }, item.i) },
+      );
+  },
+});
+
+const WIDE_GRID: Partial<GridConfig> = {
+  cols: 12,
+  rowHeight: 100,
+  margin: [10, 10],
+  containerPadding: [10, 10],
+};
+
+/**
+ * A bare grid surface that exposes the shared manager, so a test can dispatch synthetic
+ * operations through its monitor (the same channel the engine binds to).
+ */
+const DragBoard = defineComponent({
+  props: {
+    id: { type: String, required: true },
+    layout: layoutProp,
+    options: Object as PropType<Partial<UseGridControllerOptions>>,
+    onManager: Function as PropType<(manager: unknown) => void>,
+  },
+  setup(props) {
+    props.onManager?.(useDragDropManager().value);
+    const container = useGridContainer(() => ({
+      id: props.id,
+      layout: props.layout,
+      width: 1210,
+      gridConfig: WIDE_GRID,
+      ...props.options,
+    }));
+    return () => h("div", { ref: container.setRef, style: container.style.value });
+  },
+});
+
+export const DragProvider = defineComponent({
+  props: {
+    id: { type: String, required: true },
+    layout: layoutProp,
+    options: Object as PropType<Partial<UseGridControllerOptions>>,
+    onManager: Function as PropType<(manager: unknown) => void>,
+  },
+  setup(props) {
+    return () =>
+      h(DragDropProvider, null, {
+        default: () =>
+          h(DragBoard, {
+            id: props.id,
+            layout: props.layout,
+            options: props.options,
+            onManager: props.onManager,
+          }),
+      });
+  },
+});
+
+export interface Board {
+  id: string;
+  layout: Layout;
+  options?: Partial<UseGridControllerOptions>;
+}
+
+/** Two grids sharing one manager (the cross-grid seam). */
+export const CrossGrid = defineComponent({
+  props: {
+    a: { type: Object as PropType<Board>, required: true },
+    b: { type: Object as PropType<Board>, required: true },
+    onManager: Function as PropType<(manager: unknown) => void>,
+  },
+  setup(props) {
+    return () =>
+      h(DragDropProvider, null, {
+        default: () => [
+          h(DragBoard, {
+            id: props.a.id,
+            layout: props.a.layout,
+            options: props.a.options,
+            onManager: props.onManager,
+          }),
+          h(DragBoard, { id: props.b.id, layout: props.b.layout, options: props.b.options }),
+        ],
+      });
+  },
+});

--- a/packages/grid-vue/src/__tests__/grid.test.ts
+++ b/packages/grid-vue/src/__tests__/grid.test.ts
@@ -1,0 +1,174 @@
+import {
+  type GridConfig,
+  type Layout,
+  calcGridItemPosition,
+  defaultGridConfig,
+  toPositionParams,
+} from "@snapgridjs/core";
+import { render } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+import { Grid, Headless, Nested, Siblings } from "./fixtures.js";
+
+const GRID_CONFIG: Partial<GridConfig> = {
+  cols: 4,
+  rowHeight: 100,
+  margin: [10, 10],
+  containerPadding: [0, 0],
+};
+
+/** Expected pixel box for a layout cell, using the same math the engine uses. */
+function expectedBox(x: number, y: number, w: number, h: number, width: number) {
+  const pp = toPositionParams({ ...defaultGridConfig, ...GRID_CONFIG }, width);
+  return calcGridItemPosition(pp, x, y, w, h);
+}
+
+function itemEl(root: Element, id: string): HTMLElement {
+  const el = root.querySelector<HTMLElement>(`.snapgrid-item[data-grid-id="${id}"]`);
+  if (!el) throw new Error(`item ${id} not found`);
+  return el;
+}
+
+function box(el: HTMLElement) {
+  return {
+    left: el.style.left,
+    top: el.style.top,
+    width: el.style.width,
+    height: el.style.height,
+  };
+}
+
+describe("GridLayout", () => {
+  it("renders each layout item positioned by the engine math", () => {
+    const layout: Layout = [
+      { i: "a", x: 0, y: 0, w: 2, h: 2 },
+      { i: "b", x: 2, y: 0, w: 1, h: 1 },
+    ];
+    const { container } = render(Grid, { props: { layout, width: 400 } });
+
+    expect(container.querySelectorAll(".snapgrid-item")).toHaveLength(2);
+
+    const a = expectedBox(0, 0, 2, 2, 400);
+    expect(box(itemEl(container, "a"))).toEqual({
+      left: `${a.left}px`,
+      top: `${a.top}px`,
+      width: `${a.width}px`,
+      height: `${a.height}px`,
+    });
+
+    const b = expectedBox(2, 0, 1, 1, 400);
+    expect(itemEl(container, "b").style.left).toBe(`${b.left}px`);
+    // Wider item spans more columns.
+    expect(a.width).toBeGreaterThan(b.width);
+  });
+
+  it("reflows reactively when the committed layout prop changes", async () => {
+    const layout: Layout = [{ i: "a", x: 0, y: 0, w: 1, h: 1 }];
+    const { container, rerender } = render(Grid, { props: { layout, width: 400 } });
+    expect(itemEl(container, "a").style.top).toBe(`${expectedBox(0, 0, 1, 1, 400).top}px`);
+
+    await rerender({ layout: [{ i: "a", x: 0, y: 3, w: 1, h: 1 }], width: 400 });
+
+    const moved = expectedBox(0, 3, 1, 1, 400);
+    expect(itemEl(container, "a").style.top).toBe(`${moved.top}px`);
+    expect(moved.top).toBeGreaterThan(0);
+  });
+
+  it("reflows reactively when the width changes", async () => {
+    const layout: Layout = [{ i: "a", x: 1, y: 0, w: 1, h: 1 }];
+    const { container, rerender } = render(Grid, { props: { layout, width: 400 } });
+    const narrow = itemEl(container, "a").style.width;
+
+    await rerender({ layout, width: 800 });
+    const wide = itemEl(container, "a").style.width;
+
+    expect(Number.parseFloat(wide)).toBeGreaterThan(Number.parseFloat(narrow));
+  });
+
+  it("auto-sizes the surface height to the occupied rows", async () => {
+    const layout: Layout = [{ i: "a", x: 0, y: 0, w: 1, h: 1 }];
+    const { container, rerender } = render(Grid, { props: { layout, width: 400 } });
+    const surface = container.querySelector<HTMLElement>(".snapgrid");
+    if (!surface) throw new Error("surface not found");
+    const oneRow = Number.parseFloat(surface.style.height);
+    expect(oneRow).toBeGreaterThan(0);
+
+    await rerender({ layout: [{ i: "a", x: 0, y: 0, w: 1, h: 3 }], width: 400 });
+    expect(Number.parseFloat(surface.style.height)).toBeGreaterThan(oneRow);
+  });
+
+  it("renders no placeholder when idle", () => {
+    const { container } = render(Grid, {
+      props: { layout: [{ i: "a", x: 0, y: 0, w: 1, h: 1 }], width: 400 },
+    });
+    expect(container.querySelector(".snapgrid-placeholder")).toBeNull();
+  });
+
+  it("renders the configured resize handle for resizable items", () => {
+    const { container } = render(Grid, {
+      props: { layout: [{ i: "a", x: 0, y: 0, w: 1, h: 1 }], width: 400, isResizable: true },
+    });
+    const handle = itemEl(container, "a").querySelector<HTMLElement>(".snapgrid-resize-handle--se");
+    expect(handle).not.toBeNull();
+    expect(handle?.getAttribute("data-snapgrid-resize-handle")).toBe("true");
+  });
+
+  it("omits resize handles when the grid is not resizable", () => {
+    const { container } = render(Grid, {
+      props: { layout: [{ i: "a", x: 0, y: 0, w: 1, h: 1 }], width: 400, isResizable: false },
+    });
+    expect(itemEl(container, "a").querySelector(".snapgrid-resize-handle")).toBeNull();
+  });
+
+  it("omits resize handles for a locked static item", () => {
+    const { container } = render(Grid, {
+      props: { layout: [{ i: "a", x: 0, y: 0, w: 1, h: 1, static: true }], width: 400 },
+    });
+    expect(itemEl(container, "a").querySelector(".snapgrid-resize-handle")).toBeNull();
+  });
+});
+
+describe("provider structure", () => {
+  it("shares one manager across a nested grid (no duplicate provider)", () => {
+    const { container } = render(Nested, {
+      props: {
+        outer: [
+          { i: "host", x: 0, y: 0, w: 2, h: 2 },
+          { i: "o2", x: 2, y: 0, w: 1, h: 1 },
+        ],
+        inner: [{ i: "n1", x: 0, y: 0, w: 1, h: 1 }],
+      },
+    });
+    // Both outer tiles and the inner tile resolve their controllers and render;
+    // a broken dedupe would throw "no grid found" for the inner tile.
+    expect(container.querySelector('[data-grid-id="host"]')).not.toBeNull();
+    expect(container.querySelector('[data-grid-id="o2"]')).not.toBeNull();
+    expect(container.querySelector('[data-grid-id="n1"]')).not.toBeNull();
+  });
+
+  it("shares one manager across sibling grids in a SnapGridGroup", () => {
+    const { container } = render(Siblings, {
+      props: {
+        left: [{ i: "l1", x: 0, y: 0, w: 1, h: 1 }],
+        right: [{ i: "r1", x: 0, y: 0, w: 1, h: 1 }],
+      },
+    });
+    expect(container.querySelector('[data-grid-id="l1"]')).not.toBeNull();
+    expect(container.querySelector('[data-grid-id="r1"]')).not.toBeNull();
+  });
+});
+
+describe("headless composables", () => {
+  it("useGridContainer + useGridItem position tiles via the controller", () => {
+    const layout: Layout = [{ i: "a", x: 0, y: 0, w: 2, h: 1 }];
+    const { container } = render(Headless, { props: { layout, width: 400 } });
+
+    const surface = container.querySelector<HTMLElement>(".headless-surface");
+    expect(surface?.getAttribute("data-group")).toBeTruthy();
+
+    const tile = container.querySelector<HTMLElement>('.headless-tile[data-grid-id="a"]');
+    expect(tile).not.toBeNull();
+    const a = expectedBox(0, 0, 2, 1, 400);
+    expect(tile?.style.left).toBe(`${a.left}px`);
+    expect(tile?.style.width).toBe(`${a.width}px`);
+  });
+});

--- a/packages/grid-vue/src/__tests__/regressions.test.ts
+++ b/packages/grid-vue/src/__tests__/regressions.test.ts
@@ -1,0 +1,92 @@
+import type { ResponsiveLayouts } from "@snapgridjs/core";
+import { render } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
+import {
+  ResponsiveGridLayout,
+  SnapGridGroup,
+  resolveController,
+  useContainerWidth,
+} from "../index.js";
+
+describe("useContainerWidth", () => {
+  // Vue invokes a function ref on EVERY patch, not only when the element changes. If
+  // `setRef` did the observing itself, each render would disconnect and rebuild the
+  // ResizeObserver and force a synchronous layout via getBoundingClientRect — during a
+  // drag, once per commit. Observation must be keyed to element identity instead.
+  it("builds the ResizeObserver once across re-renders, not once per render", async () => {
+    let constructed = 0;
+    class SpyResizeObserver {
+      constructor(_cb: unknown) {
+        constructed += 1;
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    const original = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = SpyResizeObserver as unknown as typeof ResizeObserver;
+
+    try {
+      const Host = defineComponent({
+        props: { n: { type: Number, required: true } },
+        setup(props) {
+          const { setRef } = useContainerWidth();
+          return () => h("div", { ref: setRef }, String(props.n));
+        },
+      });
+
+      const { rerender } = render(Host, { props: { n: 1 } });
+      await rerender({ n: 2 });
+      await rerender({ n: 3 });
+
+      expect(constructed).toBe(1);
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  });
+});
+
+describe("ResponsiveGridLayout", () => {
+  // `GridLayout` declares `id` as a PROP, so an `id` fallthrough attribute would be
+  // consumed as the grid's droppable/registry key — silently making two responsive grids
+  // in one group collide on the same key.
+  it("does not let an `id` attribute become the grid's registry key", () => {
+    const layouts: ResponsiveLayouts = { lg: [{ i: "a", x: 0, y: 0, w: 1, h: 1 }] };
+
+    // Sibling rendered after the grid, so the grid has already registered by the time
+    // this resolves.
+    const Probe = defineComponent({
+      setup() {
+        let registered = true;
+        try {
+          resolveController("dashboard");
+        } catch {
+          registered = false;
+        }
+        return () => h("div", { "data-registered": String(registered) });
+      },
+    });
+
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(SnapGridGroup, null, {
+            default: () => [
+              h(
+                ResponsiveGridLayout,
+                { id: "dashboard", width: 1400, layouts },
+                { item: () => h("div") },
+              ),
+              h(Probe),
+            ],
+          });
+      },
+    });
+
+    const { container } = render(Host);
+    expect(container.querySelector("[data-registered]")?.getAttribute("data-registered")).toBe(
+      "false",
+    );
+  });
+});

--- a/packages/grid-vue/src/__tests__/responsive.test.ts
+++ b/packages/grid-vue/src/__tests__/responsive.test.ts
@@ -1,0 +1,54 @@
+import type { ResponsiveLayouts } from "@snapgridjs/core";
+import { render } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
+import { Responsive } from "./fixtures.js";
+
+const LAYOUTS: ResponsiveLayouts = {
+  lg: [
+    { i: "a", x: 0, y: 0, w: 2, h: 1 },
+    { i: "b", x: 2, y: 0, w: 2, h: 1 },
+  ],
+  xxs: [
+    { i: "a", x: 0, y: 0, w: 1, h: 1 },
+    { i: "b", x: 1, y: 0, w: 1, h: 1 },
+  ],
+};
+
+function itemWidth(root: Element, id: string): number {
+  const el = root.querySelector<HTMLElement>(`.snapgrid-item[data-grid-id="${id}"]`);
+  if (!el) throw new Error(`item ${id} not found`);
+  return Number.parseFloat(el.style.width);
+}
+
+describe("ResponsiveGridLayout", () => {
+  it("resolves the active breakpoint's layout and renders its items", () => {
+    const { container } = render(Responsive, { props: { width: 1400, layouts: LAYOUTS } });
+    expect(container.querySelectorAll(".snapgrid-item")).toHaveLength(2);
+  });
+
+  it("re-resolves columns when the width crosses a breakpoint", async () => {
+    const { container, rerender } = render(Responsive, {
+      props: { width: 1400, layouts: LAYOUTS },
+    });
+    const wideCols = itemWidth(container, "a");
+
+    // Drop to the xxs breakpoint (fewer, so each column is narrower on a small canvas).
+    await rerender({ width: 300, layouts: LAYOUTS });
+    const narrowCols = itemWidth(container, "a");
+
+    expect(narrowCols).toBeLessThan(wideCols);
+  });
+
+  it("fires onBreakpointChange when the active breakpoint changes", async () => {
+    const onBreakpointChange = vi.fn();
+    const { rerender } = render(Responsive, {
+      props: { width: 1400, layouts: LAYOUTS, onBreakpointChange },
+    });
+    onBreakpointChange.mockClear();
+
+    await rerender({ width: 300, layouts: LAYOUTS, onBreakpointChange });
+
+    expect(onBreakpointChange).toHaveBeenCalledOnce();
+    expect(onBreakpointChange).toHaveBeenCalledWith("xxs", expect.any(Number));
+  });
+});

--- a/packages/grid-vue/src/__tests__/ssr.test.ts
+++ b/packages/grid-vue/src/__tests__/ssr.test.ts
@@ -1,0 +1,46 @@
+import type { Layout } from "@snapgridjs/core";
+import { describe, expect, it } from "vitest";
+import { createSSRApp } from "vue";
+import { renderToString } from "vue/server-renderer";
+import { Grid } from "./fixtures.js";
+
+// Server render must not touch the DOM or throw: every browser-only step (the tile's
+// WAAPI FLIP, the ResizeObserver, element refs, attaching the drag engine) is guarded or
+// lives in a post-flush watcher, which Vue skips during SSR. The markup should still
+// carry engine-computed geometry so the client hydrates onto the same boxes.
+//
+// This file runs in the `vue-ssr` project (`environment: "node"`), NOT jsdom — under
+// jsdom `document`/`window` exist and the no-DOM contract would be unenforceable. The
+// guard below fails the suite if it is ever run in a DOM environment by mistake.
+
+const LAYOUT: Layout = [
+  { i: "a", x: 0, y: 0, w: 2, h: 2 },
+  { i: "b", x: 2, y: 0, w: 1, h: 1 },
+];
+
+describe("server rendering", () => {
+  it("runs with no DOM globals, so the assertions below mean something", () => {
+    expect(typeof document).toBe("undefined");
+    expect(typeof window).toBe("undefined");
+  });
+
+  it("renders a grid to a string without touching the DOM", async () => {
+    const app = createSSRApp(Grid, { layout: LAYOUT, width: 400 });
+    const html = await renderToString(app);
+
+    expect(html).toContain('class="snapgrid"');
+    expect(html).toContain('data-grid-id="a"');
+    expect(html).toContain('data-grid-id="b"');
+  });
+
+  it("positions items server-side so hydration lands on the same geometry", async () => {
+    const app = createSSRApp(Grid, { layout: LAYOUT, width: 400 });
+    const html = await renderToString(app);
+
+    // The surface is auto-sized and tiles carry absolute left/top from the engine math,
+    // not a post-mount measurement.
+    expect(html).toMatch(/position:\s*relative/);
+    expect(html).toMatch(/left:\s*\d/);
+    expect(html).toMatch(/top:\s*\d/);
+  });
+});

--- a/packages/grid-vue/src/components/DefaultResizeHandle.ts
+++ b/packages/grid-vue/src/components/DefaultResizeHandle.ts
@@ -1,0 +1,30 @@
+import type { ResizeHandleAxis } from "@snapgridjs/core";
+import { type PropType, defineComponent, h } from "vue";
+import { handleStyle } from "../handleStyle.js";
+import { useGridResizeHandle } from "../hooks/useGridResizeHandle.js";
+
+/** The default 14px edge/corner grip rendered by {@link GridItem}. */
+export const DefaultResizeHandle = defineComponent({
+  name: "SnapGridDefaultResizeHandle",
+  props: {
+    itemId: { type: String, required: true },
+    handle: { type: String as PropType<ResizeHandleAxis>, required: true },
+    group: { type: String, required: true },
+  },
+  setup(props) {
+    // Identity props, immutable per instance (handles are keyed by axis).
+    const resize = useGridResizeHandle({
+      id: props.itemId,
+      handle: props.handle,
+      group: props.group,
+    });
+
+    return () =>
+      h("span", {
+        ref: resize.setRef,
+        ...resize.handleProps,
+        class: `snapgrid-resize-handle snapgrid-resize-handle--${props.handle}`,
+        style: handleStyle(props.handle),
+      });
+  },
+});

--- a/packages/grid-vue/src/components/GridItem.ts
+++ b/packages/grid-vue/src/components/GridItem.ts
@@ -1,0 +1,55 @@
+import { computed, defineComponent, h } from "vue";
+import { useGridContext } from "../context.js";
+import { useGridItem } from "../hooks/useGridItem.js";
+import { DefaultResizeHandle } from "./DefaultResizeHandle.js";
+
+/**
+ * A positioned grid tile: renders the default-slot content plus the item's resize
+ * handles. `class` and `style` fall through and merge onto the tile element.
+ */
+export const GridItem = defineComponent({
+  name: "SnapGridItem",
+  inheritAttrs: false,
+  props: {
+    /** Matches the layout item's `i`. */
+    id: { type: String, required: true },
+    /** The owning grid's id (from its useGridContainer). */
+    group: { type: String, required: true },
+  },
+  setup(props, { slots, attrs }) {
+    // `id` and `group` are immutable per instance — tiles are keyed by `i` and a grid's
+    // group id is stable — so capturing them once at setup is correct.
+    const tile = useGridItem({ id: props.id, group: props.group });
+    const { controller, version } = useGridContext(props.group);
+
+    const handles = computed(() => {
+      version();
+      const config = controller.config;
+      return config?.isItemResizable(props.id) ? config.resizeHandlesFor(props.id) : [];
+    });
+
+    return () =>
+      h(
+        "div",
+        {
+          ...attrs,
+          ref: tile.setRef,
+          "data-grid-id": props.id,
+          "data-dragging": tile.isDragging.value || undefined,
+          class: ["snapgrid-item", attrs.class],
+          style: [tile.style.value, attrs.style],
+        },
+        [
+          slots.default?.(),
+          ...handles.value.map((axis) =>
+            h(DefaultResizeHandle, {
+              key: axis,
+              itemId: props.id,
+              handle: axis,
+              group: props.group,
+            }),
+          ),
+        ],
+      );
+  },
+});

--- a/packages/grid-vue/src/components/GridLayout.ts
+++ b/packages/grid-vue/src/components/GridLayout.ts
@@ -1,0 +1,29 @@
+import { DragDropProvider } from "@dnd-kit/vue";
+import { defineComponent, h } from "vue";
+import { markInProvider, useIsInProvider } from "../context.js";
+import { gridControllerProps } from "../props.js";
+import { GridSurface } from "./GridSurface.js";
+
+/**
+ * Drop-in grid: a controlled, react-grid-layout v2-compatible layout backed by dnd-kit.
+ * Supplies the dnd-kit `<DragDropProvider>` for the turnkey case (unless one already
+ * exists above — nested grids and `<SnapGridGroup>` siblings share it, the cross-grid
+ * seam). The surface itself lives in a child component so it sets up *inside* the
+ * provider (else the manager isn't injectable).
+ *
+ * Item content comes from the `item` scoped slot: `<template #item="{ item }">`.
+ */
+export const GridLayout = defineComponent({
+  name: "SnapGridLayout",
+  inheritAttrs: false,
+  props: gridControllerProps,
+  setup(props, { slots, attrs }) {
+    const inProvider = useIsInProvider();
+    if (!inProvider) markInProvider();
+
+    return () => {
+      const surface = h(GridSurface, { ...props, ...attrs }, slots);
+      return inProvider ? surface : h(DragDropProvider, null, { default: () => surface });
+    };
+  },
+});

--- a/packages/grid-vue/src/components/GridPlaceholder.ts
+++ b/packages/grid-vue/src/components/GridPlaceholder.ts
@@ -1,0 +1,33 @@
+import { defineComponent, h } from "vue";
+import { useGridPlaceholder } from "../hooks/useGridPlaceholder.js";
+import { REFLOW_TRANSITION } from "../reflow.js";
+
+const DEFAULT_LOOK = `background: rgba(99, 102, 241, 0.2); border: 1px dashed rgba(99, 102, 241, 0.6); border-radius: 4px; box-sizing: border-box; z-index: 2; transition: ${REFLOW_TRANSITION};`;
+
+/**
+ * The landing-cell marker shown while a drag is in progress; renders nothing when the
+ * grid is idle. `class` and `style` fall through and merge onto the element.
+ */
+export const GridPlaceholder = defineComponent({
+  name: "SnapGridPlaceholder",
+  inheritAttrs: false,
+  props: {
+    /** The owning grid's id (from its useGridContainer). */
+    group: { type: String, required: true },
+  },
+  setup(props, { attrs }) {
+    // `group` is the stable grid id for this placeholder's lifetime.
+    const placeholder = useGridPlaceholder(props.group);
+
+    return () => {
+      const current = placeholder.value;
+      if (!current) return null;
+      return h("div", {
+        ...attrs,
+        "aria-hidden": "true",
+        class: ["snapgrid-placeholder", attrs.class],
+        style: [current.style, DEFAULT_LOOK, attrs.style],
+      });
+    };
+  },
+});

--- a/packages/grid-vue/src/components/GridSurface.ts
+++ b/packages/grid-vue/src/components/GridSurface.ts
@@ -1,0 +1,44 @@
+import { defineComponent, h } from "vue";
+import { useGridContainer } from "../hooks/useGridContainer.js";
+import type { UseGridControllerOptions } from "../hooks/useGridController.js";
+import { gridControllerProps } from "../props.js";
+import { GridItem } from "./GridItem.js";
+import { GridPlaceholder } from "./GridPlaceholder.js";
+
+/**
+ * The grid surface. Exists as its own component so `useGridContainer` runs *inside* the
+ * `<DragDropProvider>` that {@link GridLayout} may render — Vue resolves `inject` from
+ * the parent chain, so a component cannot see a provider it renders itself.
+ */
+export const GridSurface = defineComponent({
+  name: "SnapGridSurface",
+  inheritAttrs: false,
+  props: gridControllerProps,
+  setup(props, { slots, attrs }) {
+    // `props` is reactive: handing it over as a getter lets the controller track
+    // whichever fields the consumer actually changes (width, layout, config).
+    const container = useGridContainer(() => props as unknown as UseGridControllerOptions);
+
+    return () =>
+      h(
+        "div",
+        {
+          ...attrs,
+          ref: container.setRef,
+          class: ["snapgrid", attrs.class],
+          style: [container.style.value, attrs.style],
+          "data-drop-target": container.isDropTarget.value || undefined,
+        },
+        [
+          ...props.layout.map((layoutItem) =>
+            h(
+              GridItem,
+              { key: layoutItem.i, id: layoutItem.i, group: container.group.value },
+              { default: () => slots.item?.({ item: layoutItem }) },
+            ),
+          ),
+          h(GridPlaceholder, { group: container.group.value }),
+        ],
+      );
+  },
+});

--- a/packages/grid-vue/src/components/ResponsiveGridLayout.ts
+++ b/packages/grid-vue/src/components/ResponsiveGridLayout.ts
@@ -1,0 +1,64 @@
+import type { GridConfig } from "@snapgridjs/core";
+import { computed, defineComponent, h } from "vue";
+import { useResponsiveLayout } from "../hooks/useResponsiveLayout.js";
+import { responsiveGridProps } from "../props.js";
+import { GridLayout } from "./GridLayout.js";
+
+/**
+ * A responsive grid: switches column count and layout by breakpoint as `width` changes,
+ * generating a breakpoint's layout from the nearest one when absent. A thin wrapper over
+ * {@link useResponsiveLayout} + {@link GridLayout}; mirrors RGL v2's
+ * ResponsiveGridLayout.
+ */
+export const ResponsiveGridLayout = defineComponent({
+  name: "SnapResponsiveGridLayout",
+  inheritAttrs: false,
+  props: responsiveGridProps,
+  setup(props, { slots, attrs }) {
+    const responsive = useResponsiveLayout(() => ({
+      width: props.width,
+      layouts: props.layouts,
+      breakpoints: props.breakpoints,
+      cols: props.cols,
+      compactor: props.compactor,
+      onLayoutChange: props.onLayoutChange,
+      onBreakpointChange: props.onBreakpointChange,
+    }));
+
+    const gridConfig = computed<Partial<GridConfig>>(() => ({
+      cols: responsive.cols.value,
+      rowHeight: props.rowHeight ?? 150,
+      margin: props.margin ?? [10, 10],
+      containerPadding: props.containerPadding ?? null,
+    }));
+
+    return () => {
+      // `GridLayout` declares `id` and `type` as PROPS, so a fallthrough attribute of
+      // either name would be consumed as the grid's droppable/registry key instead of
+      // landing on the DOM — silently making two `<ResponsiveGridLayout id="grid">` in
+      // one `<SnapGridGroup>` register under the same key. Drop them here; like React's
+      // ResponsiveGridLayout, this component deliberately doesn't expose the grid id.
+      const { id: _id, type: _type, ...passthrough } = attrs;
+      return h(
+        GridLayout,
+        {
+          ...passthrough,
+          // No explicit `id`: useGridContainer mints a stable per-instance id, which
+          // avoids droppable/registry identity churn when the breakpoint changes and
+          // keeps two responsive grids in a group from colliding on the same id.
+          layout: responsive.layout.value,
+          width: props.width,
+          onLayoutChange: responsive.onLayoutChange,
+          gridConfig: gridConfig.value,
+          compactor: props.compactor,
+          dragConfig: props.dragConfig,
+          resizeConfig: props.resizeConfig,
+          isDraggable: props.isDraggable,
+          isResizable: props.isResizable,
+          autoSize: props.autoSize,
+        },
+        slots,
+      );
+    };
+  },
+});

--- a/packages/grid-vue/src/components/SnapGridGroup.ts
+++ b/packages/grid-vue/src/components/SnapGridGroup.ts
@@ -1,0 +1,22 @@
+import { DragDropProvider } from "@dnd-kit/vue";
+import { defineComponent, h } from "vue";
+import { markInProvider, useIsInProvider } from "../context.js";
+
+/**
+ * Share one dnd-kit `<DragDropProvider>` across several sibling grids so tiles can be
+ * dragged between them. (Nested `<GridLayout>`s already share a provider; this is for
+ * siblings.) A thin wrapper — the cross-grid seam is the shared manager + collision
+ * target. Honors a consumer's own enclosing provider.
+ */
+export const SnapGridGroup = defineComponent({
+  name: "SnapGridGroup",
+  setup(_props, { slots }) {
+    const inProvider = useIsInProvider();
+    if (!inProvider) markInProvider();
+
+    return () =>
+      inProvider
+        ? slots.default?.()
+        : h(DragDropProvider, null, { default: () => slots.default?.() });
+  },
+});

--- a/packages/grid-vue/src/context.ts
+++ b/packages/grid-vue/src/context.ts
@@ -1,0 +1,61 @@
+import type { GridController } from "@snapgridjs/dnd";
+import { type InjectionKey, inject, provide } from "vue";
+
+// Grid context published by a container ({@link useGridContainer}) and read by the
+// tiles/placeholder/resize handles rendered inside it. Carries the controller plus a
+// reactive `version` tick the container bumps whenever it republishes config or the
+// committed layout — the Vue stand-in for React re-rendering the subtree on a prop
+// change. (The controller's own `subscribe` only fires on drag-state changes;
+// `setConfig`/`setCommitted` deliberately don't emit, so items depend on this tick to
+// re-read geometry after a width/layout change.)
+const GRID_KEY: InjectionKey<GridContext> = Symbol("snapgrid.grid");
+
+// Marks that a snapgrid-managed <DragDropProvider> already exists above, so a nested
+// or sibling grid doesn't mint a second dnd-kit manager. Mirrors the React binding's
+// `InProvider` context (the cross-grid / nesting seam).
+const IN_PROVIDER_KEY: InjectionKey<boolean> = Symbol("snapgrid.inProvider");
+
+export interface GridContext {
+  controller: GridController;
+  /**
+   * Reactive tick. Read it inside a `computed`/`watch` to depend on the container
+   * republishing config or the committed layout.
+   */
+  version: () => number;
+}
+
+export function provideGridContext(ctx: GridContext): void {
+  provide(GRID_KEY, ctx);
+}
+
+/**
+ * The **nearest enclosing** grid's context. Throws a helpful error when a tile is
+ * rendered outside any grid (almost always a missing container, or a tile placed
+ * outside its `useGridContainer` / `<GridLayout>`).
+ *
+ * `group` is used only to word that error — resolution is by DOM/component ancestry,
+ * not by id. A tile rendered inside grid A while declaring `group: "B"` therefore reads
+ * A's controller for its position while telling dnd-kit it belongs to B. Use
+ * {@link resolveController} for id-keyed lookup against the registry.
+ *
+ * NB: Vue resolves `inject` from the PARENT chain, so a component cannot read a context
+ * it provided itself — the container passes its own controller/version around directly
+ * rather than injecting them back.
+ */
+export function useGridContext(group?: string): GridContext {
+  const ctx = inject(GRID_KEY, undefined);
+  if (!ctx) {
+    throw new Error(
+      `snapgrid: no grid found${group ? ` for group "${group}"` : ""}. A grid item must be rendered inside a grid created by useGridContainer (or a <GridLayout>).`,
+    );
+  }
+  return ctx;
+}
+
+export function markInProvider(): void {
+  provide(IN_PROVIDER_KEY, true);
+}
+
+export function useIsInProvider(): boolean {
+  return inject(IN_PROVIDER_KEY, false);
+}

--- a/packages/grid-vue/src/element.ts
+++ b/packages/grid-vue/src/element.ts
@@ -1,0 +1,11 @@
+import type { ComponentPublicInstance } from "vue";
+
+/** What Vue hands a template function ref: an element, a component, or null on teardown. */
+export type RefTarget = Element | ComponentPublicInstance | null | undefined;
+
+/** Normalize a Vue function-ref argument to the underlying HTMLElement (or null). */
+export function toElement(value: RefTarget): HTMLElement | null {
+  if (!value) return null;
+  const el = value instanceof Element ? value : ((value as ComponentPublicInstance).$el as unknown);
+  return el instanceof HTMLElement ? el : null;
+}

--- a/packages/grid-vue/src/handleStyle.ts
+++ b/packages/grid-vue/src/handleStyle.ts
@@ -1,0 +1,33 @@
+import type { ResizeHandleAxis } from "@snapgridjs/core";
+
+const HANDLE_CURSOR: Record<ResizeHandleAxis, string> = {
+  n: "ns-resize",
+  s: "ns-resize",
+  e: "ew-resize",
+  w: "ew-resize",
+  se: "nwse-resize",
+  nw: "nwse-resize",
+  ne: "nesw-resize",
+  sw: "nesw-resize",
+};
+
+const SIDE = 14;
+
+/** Inline-style string positioning a default resize handle on its edge/corner. */
+export function handleStyle(handle: ResizeHandleAxis): string {
+  const parts = [
+    "position: absolute",
+    `width: ${SIDE}px`,
+    `height: ${SIDE}px`,
+    `cursor: ${HANDLE_CURSOR[handle]}`,
+    "touch-action: none",
+    "z-index: 4",
+  ];
+  if (handle.includes("n")) parts.push(`top: ${-SIDE / 2}px`);
+  if (handle.includes("s")) parts.push(`bottom: ${-SIDE / 2}px`);
+  if (handle.includes("e")) parts.push(`right: ${-SIDE / 2}px`);
+  if (handle.includes("w")) parts.push(`left: ${-SIDE / 2}px`);
+  if (handle === "n" || handle === "s") parts.push(`left: calc(50% - ${SIDE / 2}px)`);
+  if (handle === "e" || handle === "w") parts.push(`top: calc(50% - ${SIDE / 2}px)`);
+  return `${parts.join("; ")};`;
+}

--- a/packages/grid-vue/src/hooks/resolveController.ts
+++ b/packages/grid-vue/src/hooks/resolveController.ts
@@ -1,0 +1,23 @@
+import { useDragDropManager } from "@dnd-kit/vue";
+import { type GridController, getController } from "@snapgridjs/dnd";
+
+/**
+ * Resolve a grid's controller by its `group` (= the grid's id) from the registry,
+ * scoped to the ambient dnd-kit manager. The container registered the controller under
+ * that id. Throws a helpful error if unresolved.
+ *
+ * Prefer this for advanced/registry-based resolution; tiles created with
+ * {@link useGridItem} resolve their controller through Vue's provide/inject instead (so
+ * config changes stay reactive). Must be called during component setup, in a child of a
+ * `<DragDropProvider>`.
+ */
+export function resolveController(group: string): GridController {
+  const manager = useDragDropManager();
+  const controller = getController(manager.value, group);
+  if (!controller) {
+    throw new Error(
+      `snapgrid: no grid found for group "${group}". A grid item must pass the group returned by its grid's useGridContainer, and render inside a <DragDropProvider> (or use <GridLayout>, which wires this for you).`,
+    );
+  }
+  return controller;
+}

--- a/packages/grid-vue/src/hooks/useContainerWidth.ts
+++ b/packages/grid-vue/src/hooks/useContainerWidth.ts
@@ -1,0 +1,61 @@
+import { type Ref, shallowRef, watch } from "vue";
+import { type RefTarget, toElement } from "../element.js";
+
+export interface UseContainerWidthOptions {
+  /** Width to use until the element has been measured. @default 1280 */
+  initialWidth?: number;
+}
+
+export interface ContainerWidthHandle {
+  /** Measured container width in pixels (or `initialWidth` before mount). */
+  width: Ref<number>;
+  /** Whether the element has been measured at least once. */
+  mounted: Ref<boolean>;
+  /** Function ref for the element whose width drives the grid. */
+  setRef: (el: RefTarget) => void;
+}
+
+/**
+ * Measure a container's width with a `ResizeObserver`, exposed as reactive refs.
+ * Replaces react-grid-layout's `WidthProvider` HOC, mirroring RGL v2's
+ * `useContainerWidth`. SSR-safe: measurement only runs once the element is bound on the
+ * client, so server render uses `initialWidth` and the measured width applies right
+ * after mount.
+ */
+export function useContainerWidth(options: UseContainerWidthOptions = {}): ContainerWidthHandle {
+  const { initialWidth = 1280 } = options;
+  const width = shallowRef(initialWidth);
+  const mounted = shallowRef(false);
+  const elRef = shallowRef<HTMLElement | null>(null);
+
+  // Vue invokes a function ref on EVERY patch, not just when the element changes, so
+  // this must stay a pure assignment. Writing the same node to a shallowRef doesn't
+  // trigger, which is what keys the observer effect below to element identity — the
+  // equivalent of React's `[element]` dep and Svelte's attachment lifecycle. Doing the
+  // observe/disconnect here instead would rebuild the ResizeObserver and force a
+  // synchronous layout on every render.
+  const setRef = (el: RefTarget): void => {
+    elRef.value = toElement(el);
+  };
+
+  watch(
+    elRef,
+    (node, _prev, onCleanup) => {
+      if (!node || typeof ResizeObserver === "undefined") return;
+      const measure = () => {
+        const next = node.getBoundingClientRect().width;
+        if (next > 0) {
+          width.value = next;
+          mounted.value = true;
+        }
+      };
+      measure();
+      const observer = new ResizeObserver(measure);
+      observer.observe(node);
+      onCleanup(() => observer.disconnect());
+    },
+    { flush: "post" },
+  );
+
+  return { width, mounted, setRef };
+}

--- a/packages/grid-vue/src/hooks/useGridContainer.ts
+++ b/packages/grid-vue/src/hooks/useGridContainer.ts
@@ -1,0 +1,135 @@
+import { useDroppable } from "@dnd-kit/vue";
+import { type GridConfig, bottom } from "@snapgridjs/core";
+import {
+  type GridController,
+  SNAPGRID_GRID_ATTR,
+  domElement,
+  gridCollisionDetector,
+} from "@snapgridjs/dnd";
+import { type ComputedRef, computed, shallowRef, watch } from "vue";
+import { type RefTarget, toElement } from "../element.js";
+import { controllerTick } from "../reactivity.js";
+import { type UseGridControllerOptions, setupGridController } from "./useGridController.js";
+
+export interface GridContainerResult {
+  /**
+   * Function ref for your container element: `<div :ref="container.setRef">`.
+   * Feeds the droppable, reports the element to the controller, and stamps the
+   * nesting-depth marker.
+   */
+  setRef: (el: RefTarget) => void;
+  /** Reactive inline-style string (position + width + auto-sized height). */
+  style: ComputedRef<string>;
+  /** True while a compatible draggable is over the grid. */
+  isDropTarget: ComputedRef<boolean>;
+  /** This grid's id — pass as the `group` to tiles rendered inside. */
+  group: ComputedRef<string>;
+  /** The grid's controller (for advanced/headless composition). */
+  controller: GridController;
+}
+
+/** Total container height in pixels for the given number of occupied rows. */
+function containerHeight(rows: number, grid: GridConfig): number {
+  const padY = (grid.containerPadding ?? grid.margin)[1];
+  if (rows <= 0) return padY * 2;
+  return padY * 2 + rows * grid.rowHeight + (rows - 1) * grid.margin[1];
+}
+
+/**
+ * The grid host: creates this grid's controller + drag engine (see
+ * {@link useGridController}), registers the droppable surface, and returns a `setRef`
+ * function ref plus a reactive style for your own container element. Render tiles
+ * inside via {@link useGridItem}, passing `group` (this grid's id) so they resolve
+ * this controller.
+ *
+ * Must be called during component setup, in a CHILD component of a
+ * `<DragDropProvider>` (supplied by `<GridLayout>` / `<SnapGridGroup>` for the
+ * turnkey case) — Vue resolves `inject` from the parent chain, so a component that
+ * renders the provider itself cannot see its manager.
+ */
+export function useGridContainer(getOpts: () => UseGridControllerOptions): GridContainerResult {
+  const { controller, version } = setupGridController(getOpts);
+  const tick = controllerTick(controller);
+
+  // The container element: fed to the droppable, and tracked for the ancestry guard
+  // (reject dropping a host tile into the nested grid it contains).
+  const elRef = shallowRef<HTMLElement | null>(null);
+
+  // Reject a source whose element CONTAINS this grid — an ancestor tile that hosts
+  // this nested grid — so a host tile can't be dropped into the grid it contains now
+  // that nested grids share one manager.
+  const accept = (source: Parameters<typeof domElement>[0] & { data?: unknown }): boolean => {
+    const srcEl = domElement(source);
+    const gridEl = elRef.value;
+    if (srcEl && gridEl && srcEl.contains(gridEl)) return false;
+    const data = source.data as { snapGrid?: unknown; snapGridDrop?: unknown } | undefined;
+    // A grid tile is identified by its `snapGrid` payload, not its `type`.
+    if (data?.snapGrid != null) return true;
+    if (data?.snapGridDrop != null) return true;
+    // Consumer extension: accept foreign dnd-kit draggables for interop; the receive
+    // is driven via snapMove.
+    return getOpts().accept?.(source as never) ?? false;
+  };
+
+  const dropHandle = useDroppable({
+    id: () => {
+      version();
+      return controller.id;
+    },
+    type: () => getOpts().type ?? "grid",
+    // `accept` and `collisionDetector` are themselves FUNCTIONS, and dnd-kit's Vue
+    // adapter resolves every input with `toValue()` — which invokes a bare function as
+    // a getter. Wrap them so `toValue` yields the function instead of calling it.
+    accept: () => accept,
+    collisionDetector: () => gridCollisionDetector,
+    element: elRef,
+  });
+
+  // Vue invokes a function ref on EVERY patch, not just when the element changes, so
+  // this stays a pure assignment and the side effects below key off element identity
+  // (writing the same node to a shallowRef doesn't trigger).
+  const setRef = (el: RefTarget): void => {
+    elRef.value = toElement(el);
+  };
+
+  // Report the element to the controller (the engine reads it to map the pointer to a
+  // cell when receiving a tile) and stamp the grid marker so nested grids can measure
+  // their depth.
+  watch(
+    elRef,
+    (node, prev) => {
+      if (prev && controller.element === prev) controller.element = null;
+      if (node) {
+        controller.element = node;
+        node.setAttribute(SNAPGRID_GRID_ATTR, "");
+      }
+    },
+    { flush: "post" },
+  );
+
+  // Auto-height tracks the rendered layout (drag preview while dragging, else
+  // committed) so the surface grows/shrinks as the grid reflows. Depends on both the
+  // drag tick (preview changes) and the republish tick (width/config changes).
+  const style = computed(() => {
+    version();
+    tick();
+    const config = controller.config;
+    if (!config) return "position: relative;";
+    const rendered = controller.renderedSnapshot();
+    const height = config.autoSize
+      ? containerHeight(bottom(rendered), config.gridConfig)
+      : undefined;
+    return `position: relative; width: ${config.width}px;${height != null ? ` height: ${height}px;` : ""}`;
+  });
+
+  return {
+    setRef,
+    style,
+    isDropTarget: computed(() => dropHandle.isDropTarget.value === true),
+    group: computed(() => {
+      version();
+      return controller.id;
+    }),
+    controller,
+  };
+}

--- a/packages/grid-vue/src/hooks/useGridController.ts
+++ b/packages/grid-vue/src/hooks/useGridController.ts
@@ -1,0 +1,259 @@
+import { useDragDropManager } from "@dnd-kit/vue";
+import {
+  type Compactor,
+  type GridConfig,
+  type Layout,
+  type LayoutItem,
+  type PositionParams,
+  defaultGridConfig,
+  toPositionParams,
+  verticalCompactor,
+} from "@snapgridjs/core";
+import {
+  type DragConfig,
+  type DragSourceInfo,
+  type DropConfig,
+  GridController,
+  type GridEventCallback,
+  type ResizeConfig,
+  SnapToGrid,
+  attachEngine,
+  buildItemSensors,
+  registerController,
+} from "@snapgridjs/dnd";
+import { shallowRef, useId, watchEffect } from "vue";
+import { provideGridContext } from "../context.js";
+
+const DEFAULT_HANDLES = ["se"] as const;
+
+// Fallback when `useId()` is unavailable (a composable called outside a component
+// instance, e.g. a bare effect scope in a test).
+let gridIdCounter = 0;
+function nextGridId(): string {
+  return `snapgrid-${gridIdCounter++}`;
+}
+
+// Per-item drag/resize gate. Mirrors RGL's engine rule: a `static` item is locked
+// unless its flag (`isDraggable`/`isResizable`) is explicitly `true` ("pinned");
+// a non-static item just follows the flag (default `true`).
+function itemGateOpen(flag: boolean | undefined, isStatic: boolean | undefined): boolean {
+  return isStatic ? flag === true : (flag ?? true);
+}
+
+/** Options the grid host ({@link useGridContainer}) feeds the controller. */
+export interface UseGridControllerOptions {
+  /** Stable id for the grid's droppable surface (auto-generated if omitted). */
+  id?: string;
+  /**
+   * The dnd-kit `type` the grid's droppable surface carries. Defaults to `"grid"`.
+   * Override to namespace grids for ecosystem interop — e.g. so a foreign draggable
+   * `accept`s only one grid, or you branch `onDragOver` on a specific grid type.
+   * Nothing internal depends on this string (grids resolve by id), so any value
+   * still receives tiles and cross-grid drops.
+   */
+  type?: string;
+  /** Container width in pixels (e.g. from {@link useContainerWidth}). */
+  width: number;
+  /** Controlled layout. Never mutated. */
+  layout: Layout;
+  onLayoutChange?: (layout: Layout) => void;
+  gridConfig?: Partial<GridConfig>;
+  dragConfig?: DragConfig;
+  resizeConfig?: ResizeConfig;
+  dropConfig?: DropConfig;
+  /**
+   * Accept additional (non-grid) dnd-kit draggables as drop targets — e.g. a
+   * `useSortable` card from a sibling list, for interop. Extends the built-in
+   * acceptance (grid tiles + `snapGridDrop` externals); the ancestry guard still
+   * applies. You drive the actual receive in your own `onDragOver` with `snapMove`.
+   */
+  accept?: (source: DragSourceInfo) => boolean;
+  compactor?: Compactor;
+  isDraggable?: boolean;
+  isResizable?: boolean;
+  autoSize?: boolean;
+  onDragStart?: GridEventCallback;
+  onDrag?: GridEventCallback;
+  onDragStop?: GridEventCallback;
+  onResizeStart?: GridEventCallback;
+  onResize?: GridEventCallback;
+  onResizeStop?: GridEventCallback;
+  onDrop?: (layout: Layout, item: LayoutItem, event: Event | null) => void;
+}
+
+/** Internal: the controller plus the republish tick the container needs directly. */
+export interface GridControllerSeam {
+  controller: GridController;
+  version: () => number;
+}
+
+/**
+ * The grid's Vue seam: owns the {@link GridController} (an observable render bridge),
+ * publishes per-grid config to it reactively, registers it for id → controller
+ * resolution, and attaches the manager-wide engine.
+ *
+ * `getOpts` is a getter so the controller stays reactive to the consumer's live state
+ * (width, layout, config): reading it inside the publish `watchEffect` tracks
+ * whichever fields change. `watchEffect` runs its first pass synchronously during
+ * setup — before child tiles set up — so they read fresh geometry on their first pass
+ * (the Vue analog of the React binding writing config during render).
+ *
+ * Consumes the ambient dnd-kit `DragDropProvider`; it does not mint one. Must be
+ * called during component setup, in a CHILD of the provider (Vue resolves `inject`
+ * from the parent chain).
+ */
+export function setupGridController(getOpts: () => UseGridControllerOptions): GridControllerSeam {
+  const manager = useDragDropManager();
+  const first = getOpts();
+  const autoId = useId();
+  const initialId = first.id ?? (autoId ? `snapgrid-${autoId}` : nextGridId());
+
+  // Built directly rather than via dnd-kit's `useInstance`: that helper feeds
+  // `register()`'s return value to `onWatcherCleanup`, and `GridController.register`
+  // is a deliberate no-op returning `undefined`, which makes Vue log an "Invalid value
+  // type passed to callWithAsyncErrorHandling" warning on every teardown. The helper
+  // would only set `.manager` and call that no-op, both of which we do here.
+  const controller = new GridController(initialId, first.layout, manager.value);
+
+  // Live snapshots the once-built sensor/modifier descriptors read lazily, so the
+  // descriptors stay identity-stable while still seeing the latest config.
+  let latestOpts = first;
+  let latestPositionParams: PositionParams = toPositionParams(
+    { ...defaultGridConfig, ...first.gridConfig },
+    first.width,
+  );
+
+  // Snap-to-grid modifier: a stable descriptor reading live refs (a no-op unless
+  // `dragConfig.snapToGrid` is set).
+  const itemModifiers = [
+    SnapToGrid.configure({
+      getPositionParams: () => latestPositionParams,
+      isEnabled: () => latestOpts.dragConfig?.snapToGrid ?? false,
+    }),
+  ];
+
+  // Item sensors read the live drag config; rebuilt only when the distance threshold
+  // changes (it's captured by value), mirroring the React memo.
+  let builtThreshold = first.dragConfig?.threshold ?? 3;
+  let itemSensors = buildItemSensors(builtThreshold, () => latestOpts.dragConfig);
+
+  // Reactive tick the container bumps on every republish, so tiles re-read geometry
+  // after a width/layout/config change (the controller's own `subscribe` only fires
+  // on drag-state changes).
+  const version = shallowRef(0);
+  let versionCount = 0;
+
+  function publish(opts: UseGridControllerOptions): void {
+    latestOpts = opts;
+    const id = opts.id ?? initialId;
+    if (controller.id !== id) controller.setId(id);
+
+    const gridConfig: GridConfig = { ...defaultGridConfig, ...opts.gridConfig };
+    const positionParams = toPositionParams(gridConfig, opts.width);
+    latestPositionParams = positionParams;
+    const compactor: Compactor = opts.compactor ?? verticalCompactor;
+
+    controller.setCommitted(opts.layout);
+
+    const threshold = opts.dragConfig?.threshold ?? 3;
+    if (threshold !== builtThreshold) {
+      builtThreshold = threshold;
+      itemSensors = buildItemSensors(threshold, () => latestOpts.dragConfig);
+    }
+
+    const committedById = new Map<string, LayoutItem>(opts.layout.map((it) => [it.i, it]));
+
+    const gridDraggable = opts.isDraggable ?? true;
+    const dragEnabled = opts.dragConfig?.enabled ?? true;
+    const isItemDraggable = (itemId: string): boolean => {
+      const it = committedById.get(itemId);
+      if (!it) return false;
+      return gridDraggable && dragEnabled && itemGateOpen(it.isDraggable, it.static);
+    };
+
+    const gridResizable = opts.isResizable ?? true;
+    const resizeEnabled = opts.resizeConfig?.enabled ?? true;
+    const isItemResizable = (itemId: string): boolean => {
+      const it = committedById.get(itemId);
+      if (!it) return false;
+      return gridResizable && resizeEnabled && itemGateOpen(it.isResizable, it.static);
+    };
+
+    const defaultHandles = opts.resizeConfig?.handles;
+    const resizeHandlesFor = (itemId: string) =>
+      committedById.get(itemId)?.resizeHandles ?? defaultHandles ?? DEFAULT_HANDLES;
+
+    controller.setConfig({
+      positionParams,
+      gridConfig,
+      width: opts.width,
+      autoSize: opts.autoSize ?? true,
+      itemSensors,
+      itemModifiers,
+      isItemDraggable,
+      isItemResizable,
+      resizeHandlesFor,
+      compactor,
+      dragConfig: opts.dragConfig,
+      dropConfig: opts.dropConfig,
+      callbacks: {
+        onDragStart: opts.onDragStart,
+        onDrag: opts.onDrag,
+        onDragStop: opts.onDragStop,
+        onResizeStart: opts.onResizeStart,
+        onResize: opts.onResize,
+        onResizeStop: opts.onResizeStop,
+        onLayoutChange: opts.onLayoutChange,
+        onDrop: opts.onDrop,
+      },
+    });
+    // Bump the republish tick with a bare WRITE: `publish` runs inside a
+    // `watchEffect`, and `version.value++` would read+write the same ref, making the
+    // effect depend on itself and loop. Assigning from a plain counter only triggers.
+    version.value = ++versionCount;
+  }
+
+  // Register synchronously during setup so child tiles (and `resolveController`)
+  // resolve this controller on their first setup — children set up after the parent's
+  // setup body runs. The effect below owns cleanup + id changes.
+  registerController(manager.value, initialId, controller);
+
+  // Keep the registry key in sync with a changing `id`, and unregister on teardown.
+  watchEffect((onCleanup) => {
+    const id = getOpts().id ?? initialId;
+    if (controller.id !== id) controller.setId(id);
+    onCleanup(registerController(manager.value, id, controller));
+  });
+
+  // Republish per-grid config whenever the consumer's reactive options change. The
+  // first pass runs synchronously here, publishing the initial config before children
+  // set up.
+  watchEffect(() => {
+    publish(getOpts());
+  });
+
+  // Attach the manager-wide drag/resize engine (ref-counted; one per manager, shared
+  // by every grid on it). Detaches when the last grid unmounts.
+  watchEffect((onCleanup) => {
+    controller.manager = manager.value;
+    // Vue runs `watchEffect` bodies once during SSR (that's what puts engine-computed
+    // geometry in the server HTML two effects up). There are no drags on the server, so
+    // skip building the engine and its monitor listeners on every server render — and
+    // its refcount, which no cleanup would ever decrement there.
+    if (typeof window === "undefined") return;
+    onCleanup(attachEngine(manager.value));
+  });
+
+  const versionGetter = () => version.value;
+  provideGridContext({ controller, version: versionGetter });
+  return { controller, version: versionGetter };
+}
+
+/**
+ * Create and own a grid's {@link GridController} without rendering a surface — the
+ * advanced seam under {@link useGridContainer}. Most consumers want
+ * `useGridContainer` instead.
+ */
+export function useGridController(getOpts: () => UseGridControllerOptions): GridController {
+  return setupGridController(getOpts).controller;
+}

--- a/packages/grid-vue/src/hooks/useGridItem.ts
+++ b/packages/grid-vue/src/hooks/useGridItem.ts
@@ -1,0 +1,293 @@
+import type { Plugins } from "@dnd-kit/abstract";
+import { type Draggable, Feedback } from "@dnd-kit/dom";
+import { OptimisticSortingPlugin } from "@dnd-kit/dom/sortable";
+import { isKeyboardEvent } from "@dnd-kit/dom/utilities";
+import { type UseSortableInput, useSortable } from "@dnd-kit/vue/sortable";
+import { type LayoutItem, calcGridItemPosition } from "@snapgridjs/core";
+import { type ComputedRef, computed, onScopeDispose, shallowRef, watch } from "vue";
+import { useGridContext } from "../context.js";
+import { type RefTarget, toElement } from "../element.js";
+import { controllerTick } from "../reactivity.js";
+import { REFLOW_EASING, REFLOW_MS, TILE_TRANSITION } from "../reflow.js";
+
+// A pointer drag floats the tile via dnd-kit's default feedback; a keyboard drag gets
+// `none` (no pointer — the tile steps in place via the session). The drop tween is
+// disabled so a pointer drop lands at the cell, not the float origin.
+const ITEM_FEEDBACK = [
+  Feedback.configure({
+    feedback: (_source: Draggable, manager) =>
+      isKeyboardEvent(manager.dragOperation.activatorEvent) ? "none" : "default",
+    dropAnimation: null,
+  }),
+];
+
+// Drop the optimistic-sorting plugin (it reorders DOM nodes directly during a drag and
+// fights Vue's `v-for` patcher, just as it fights Svelte's `{#each}` reconciler) and
+// append the grid tile's feedback config.
+const itemPlugins = (defaults: Plugins): Plugins => [
+  ...defaults.filter((p) => p !== OptimisticSortingPlugin),
+  ...ITEM_FEEDBACK,
+];
+
+// A grid tile is never itself a drop target — the grid CONTAINER (a separate,
+// higher-priority droppable) is what a drag resolves onto. Keeping tiles out of the
+// target pool also stops the sortable optimistic-sorting reparenting from fighting the
+// framework's list reconciler.
+const tileNeverTarget = () => null;
+
+export interface UseGridItemOptions {
+  /** Matches the layout item's `i`. */
+  id: string;
+  /** The owning grid's id, from its {@link useGridContainer} (dnd-kit's `group`). */
+  group: string;
+  /**
+   * The dnd-kit sortable `type` this tile carries. Defaults to `"grid-item"`.
+   * Override to namespace tiles for ecosystem interop. The grid recognizes its own
+   * tiles by their payload, not this string, so any value still drags + crosses grids.
+   */
+  type?: string;
+}
+
+export interface GridItemHandle {
+  /**
+   * Function ref for the tile element: `<div :ref="tile.setRef">`. Feeds the sortable
+   * and captures the node for the reflow FLIP.
+   */
+  setRef: (el: RefTarget) => void;
+  /**
+   * Optional drag-handle function ref. Bind it to a child element to restrict
+   * **pointer** drag activation to that element; omit and the whole tile drags.
+   * Keyboard pickup (Enter/Space on a focused tile) is unaffected.
+   */
+  setHandleRef: (el: RefTarget) => void;
+  /** Reactive inline-style string (position + size). */
+  style: ComputedRef<string>;
+  /** True while this item is the active drag source. */
+  isDragging: ComputedRef<boolean>;
+  /** The item's current (possibly reflowed) layout entry. */
+  item: ComputedRef<LayoutItem | undefined>;
+}
+
+/**
+ * Headless composable for a single grid tile. The tile is a real `useSortable` (a
+ * draggable + droppable carrying `group`/`index`/`type`), so it interoperates with the
+ * dnd-kit sortable ecosystem, yet it is positioned by RGL via the controller. `group`
+ * is the owning grid's id (from its {@link useGridContainer}).
+ *
+ * The dragged tile floats itself via dnd-kit's default feedback (no drag overlay): the
+ * active tile renders at its committed origin and dnd-kit's float follows the pointer,
+ * while reflow is animated on the compositor via the Web Animations API (a FLIP) —
+ * both so it stays smooth in Safari. Tiles rest on `left`/`top` (not `transform`) so
+ * the float hands off cleanly when a tile is swapped for a foreign one mid-drag
+ * (grid → sortable interop).
+ *
+ * `id` and `group` are read once at setup and are expected to be immutable for the
+ * tile's lifetime (tiles are keyed by `i`, and a grid's id is stable). Changing the
+ * owning grid's `id` prop while its tiles stay mounted would leave them bound to the old
+ * group — mirroring the Svelte binding. Give a remounted grid a fresh `key` if its id
+ * must change.
+ *
+ * Must be called during component setup, inside a grid container.
+ */
+export function useGridItem(opts: UseGridItemOptions): GridItemHandle {
+  const { id, group, type = "grid-item" } = opts;
+  const { controller, version } = useGridContext(group);
+  const tick = controllerTick(controller);
+
+  const elRef = shallowRef<HTMLElement | null>(null);
+  const handleElRef = shallowRef<HTMLElement | null>(null);
+
+  // This item's slice — re-read on drag-state changes (tick) and config/committed
+  // republish (version). A drag elsewhere still recomputes the computed, but the
+  // controller's value-cached snapshot returns a stable reference when nothing in this
+  // item's slice changed, so downstream computeds don't churn.
+  const snap = computed(() => {
+    version();
+    tick();
+    return controller.itemSnapshot(id);
+  });
+  const session = computed(() => {
+    tick();
+    return controller.getSession();
+  });
+
+  const item = computed(() => snap.value.item);
+  const active = computed(() => snap.value.isDragging);
+  // The "pointer move in progress" signal (false for a keyboard drag): used to pin the
+  // tile at its origin for the float, not to hide it (it floats itself).
+  const hidden = computed(() => snap.value.hidden);
+  const dragging = computed(() => session.value != null);
+
+  // Stable-ish drag payload; `group` lets the engine resolve this tile's owning grid.
+  const data = computed(() => ({
+    snapGrid: { kind: "move", itemId: id, item: item.value, group },
+  }));
+
+  // During a POINTER drag the active tile renders at its committed origin so dnd-kit's
+  // float offset tracks the pointer; a keyboard drag (and every other tile) renders at
+  // the reflowed (preview) cell so it steps with the arrow keys.
+  const posItem = computed(() => {
+    version();
+    const it = item.value;
+    if (!it) return undefined;
+    return active.value && hidden.value ? (session.value?.anchor.item ?? it) : it;
+  });
+  const pos = computed(() => {
+    version();
+    const pi = posItem.value;
+    if (!pi) return undefined;
+    const config = controller.config;
+    if (!config) return undefined;
+    return calcGridItemPosition(config.positionParams, pi.x, pi.y, pi.w, pi.h);
+  });
+
+  const sortable = useSortable({
+    id,
+    // itemIndex(id) is assigned once and stable for this tile's life (config- and
+    // drag-independent), so no reactive dep is read here — a spurious one would re-run
+    // the sortable's index effect (refreshShape) on every unrelated republish.
+    index: () => controller.itemIndex(id),
+    group,
+    type,
+    accept: type,
+    // `collisionDetector` and the `plugins` callback are themselves FUNCTIONS, and
+    // dnd-kit's Vue adapter resolves every input with `toValue()` — which invokes a
+    // bare function as a getter. Wrap them so `toValue` yields the function itself.
+    collisionDetector: () => tileNeverTarget,
+    // `Customizable<Plugins>` already includes the `(defaults) => Plugins` callback
+    // form, so "a getter that RETURNS the callback" is inexpressible in the input type.
+    // Escape this one field only; every other option below stays typechecked.
+    plugins: (() => itemPlugins) as unknown as UseSortableInput["plugins"],
+    disabled: () => {
+      version();
+      return !controller.config?.isItemDraggable(id);
+    },
+    sensors: () => {
+      version();
+      return controller.config?.itemSensors;
+    },
+    modifiers: () => {
+      version();
+      return controller.config?.itemModifiers;
+    },
+    // Carry the full item so a receiving grid can render/insert it on a cross-grid drop.
+    data,
+    element: elRef,
+    handle: handleElRef,
+  });
+
+  const setRef = (el: RefTarget): void => {
+    elRef.value = toElement(el);
+  };
+  const setHandleRef = (el: RefTarget): void => {
+    handleElRef.value = toElement(el);
+  };
+
+  // True on the single update where the tile goes active → settled (the drop frame):
+  // snap to the landed cell instead of sliding there from the committed origin.
+  // Recomputed on any positional/drag change (the Vue analog of "every render"), so it
+  // is set only on the frame the tile stops being the drag source and cleared on the
+  // next change regardless of its cause.
+  let wasActive = false;
+  const justDropped = shallowRef(false);
+  watch(
+    [active, dragging, pos],
+    () => {
+      const a = active.value;
+      justDropped.value = wasActive && !a;
+      wasActive = a;
+    },
+    { flush: "pre", immediate: true },
+  );
+
+  // Reflow a tile to its new cell via a compositor FLIP: the resting left/top has
+  // already jumped this update, so animate a `transform` delta from the tile's previous
+  // visual position back to 0. Drives in-drag reflow AND out-of-drag (responsive /
+  // programmatic) changes, and dodges the float's popover repaint that janks a CSS
+  // transition in Safari. The drag source settling after a drop is the exception (see
+  // the `settleAnchor` branch).
+  let prev: { left: number; top: number } | null = null;
+  let reflowAnim: Animation | null = null;
+  let settleAnchor: { left: number; top: number } | null = null;
+  watch(
+    [pos, active, dragging, justDropped],
+    () => {
+      const p = pos.value;
+      const cur = p ? { left: p.left, top: p.top } : null;
+      const isActive = active.value;
+      const isDragging = dragging.value;
+      const dropped = justDropped.value;
+      const before = prev;
+      prev = cur;
+      const el = elRef.value;
+      if (!el || !cur) return;
+
+      // Active: dnd-kit owns this tile's motion. Remember the cell it floats from so the
+      // post-drop settle can snap instead of FLIP.
+      if (isActive) {
+        settleAnchor = cur;
+        reflowAnim?.cancel();
+        return;
+      }
+      // A drag of ANOTHER tile in this grid: this tile reflows normally; drop any stale
+      // settle anchor so it FLIPs (it was never floated).
+      if (isDragging) {
+        settleAnchor = null;
+      }
+      // Post-drop settle of the formerly-active source: it was floated, so `before` is
+      // the committed origin, not where it visually was — snap (no FLIP) until the
+      // committed move lands (cell leaves the anchor).
+      else if (settleAnchor) {
+        const a = settleAnchor;
+        reflowAnim?.cancel();
+        if (cur.left !== a.left || cur.top !== a.top) settleAnchor = null;
+        return;
+      }
+
+      if (!before || dropped) return;
+      if (before.left === cur.left && before.top === cur.top) return;
+      // Web Animations API may be absent (jsdom / SSR / very old browsers): degrade to
+      // an instant move (the left/top already places the tile) rather than throw.
+      if (typeof el.animate !== "function") return;
+      // Previous visual position = the prior resting cell plus any in-flight transform.
+      let fromX = before.left;
+      let fromY = before.top;
+      if (reflowAnim?.playState === "running") {
+        const m = new DOMMatrix(getComputedStyle(el).transform);
+        fromX = before.left + m.m41;
+        fromY = before.top + m.m42;
+      }
+      reflowAnim?.cancel();
+      reflowAnim = el.animate(
+        [
+          { transform: `translate(${fromX - cur.left}px, ${fromY - cur.top}px)` },
+          { transform: "translate(0px, 0px)" },
+        ],
+        { duration: REFLOW_MS, easing: REFLOW_EASING },
+      );
+    },
+    { flush: "post", immediate: true },
+  );
+
+  // Cancel any in-flight reflow animation when the tile unmounts (e.g. removed mid-drag
+  // during a cross-grid move) so a running Animation can't outlive its node.
+  onScopeDispose(() => reflowAnim?.cancel());
+
+  // Tiles rest on left/top (see the doc above); position animates via the FLIP, so the
+  // CSS transition is SIZE-only — and "none" while dragging (FLIP owns motion) or
+  // just-dropped (it snaps).
+  const style = computed(() => {
+    const p = pos.value;
+    if (!p) return "position: absolute; touch-action: none;";
+    const transition = justDropped.value || dragging.value ? "none" : TILE_TRANSITION;
+    return `position: absolute; left: ${p.left}px; top: ${p.top}px; width: ${p.width}px; height: ${p.height}px; transition: ${transition}; touch-action: none;`;
+  });
+
+  return {
+    setRef,
+    setHandleRef,
+    style,
+    isDragging: computed(() => sortable.isDragging.value === true),
+    item,
+  };
+}

--- a/packages/grid-vue/src/hooks/useGridPlaceholder.ts
+++ b/packages/grid-vue/src/hooks/useGridPlaceholder.ts
@@ -1,0 +1,42 @@
+import { type LayoutItem, calcGridItemPosition } from "@snapgridjs/core";
+import { type ComputedRef, computed } from "vue";
+import { useGridContext } from "../context.js";
+import { controllerTick } from "../reactivity.js";
+
+export interface GridPlaceholderInfo {
+  /** The layout entry marking where the dragged item will land. */
+  item: LayoutItem;
+  /** Positioning inline-style string (left/top/size) for your placeholder element. */
+  style: string;
+}
+
+/**
+ * Headless composable returning where the drag placeholder should be rendered, or
+ * `null` when no drag is in progress. `group` is the owning grid's id (from its
+ * {@link useGridContainer}). Render the element however you like.
+ *
+ * Must be called during component setup, inside a grid container.
+ */
+export function useGridPlaceholder(group: string): ComputedRef<GridPlaceholderInfo | null> {
+  const { controller, version } = useGridContext(group);
+  const tick = controllerTick(controller);
+
+  return computed((): GridPlaceholderInfo | null => {
+    version();
+    tick();
+    const placeholder = controller.placeholderSnapshot();
+    const config = controller.config;
+    if (!placeholder || !config) return null;
+    const pos = calcGridItemPosition(
+      config.positionParams,
+      placeholder.x,
+      placeholder.y,
+      placeholder.w,
+      placeholder.h,
+    );
+    // Transform-positioned to match grid items — the placeholder slides as a GPU
+    // transform, not an animated left/top.
+    const style = `position: absolute; left: 0; top: 0; width: ${pos.width}px; height: ${pos.height}px; transform: translate(${pos.left}px, ${pos.top}px); pointer-events: none;`;
+    return { item: placeholder, style };
+  });
+}

--- a/packages/grid-vue/src/hooks/useGridResizeHandle.ts
+++ b/packages/grid-vue/src/hooks/useGridResizeHandle.ts
@@ -1,0 +1,63 @@
+import { useDraggable } from "@dnd-kit/vue";
+import type { ResizeHandleAxis } from "@snapgridjs/core";
+import { NO_FEEDBACK, RESIZE_HANDLE_ATTR } from "@snapgridjs/dnd";
+import { type ComputedRef, computed, shallowRef } from "vue";
+import { useGridContext } from "../context.js";
+import { type RefTarget, toElement } from "../element.js";
+import { controllerTick } from "../reactivity.js";
+
+export interface UseGridResizeHandleOptions {
+  /** Matches the layout item's `i` — the item this handle resizes. */
+  id: string;
+  /** Which edge/corner this handle drives. */
+  handle: ResizeHandleAxis;
+  /** The owning grid's id, from its {@link useGridContainer}. */
+  group: string;
+}
+
+export interface GridResizeHandle {
+  /** Function ref for the handle element: `<span :ref="handle.setRef">`. */
+  setRef: (el: RefTarget) => void;
+  /** Bind onto the handle element so item drags ignore pointer-downs on it. */
+  handleProps: { [RESIZE_HANDLE_ATTR]: true };
+  /** True while this item is actively being resized. */
+  isResizing: ComputedRef<boolean>;
+}
+
+/**
+ * Headless composable for a single resize handle. Model a handle as its own draggable;
+ * dragging it resizes the item from the given edge/corner. `group` is the owning grid's
+ * id (from its {@link useGridContainer}).
+ *
+ * Must be called during component setup, inside a grid container.
+ */
+export function useGridResizeHandle(opts: UseGridResizeHandleOptions): GridResizeHandle {
+  const { id, handle, group } = opts;
+  const { controller, version } = useGridContext(group);
+  const tick = controllerTick(controller);
+
+  const elRef = shallowRef<HTMLElement | null>(null);
+
+  useDraggable({
+    id: `${id}::resize::${handle}`,
+    disabled: () => {
+      version();
+      return !controller.config?.isItemResizable(id);
+    },
+    // NO_FEEDBACK is a plain array (not the callback form), so it needs no getter wrap.
+    plugins: NO_FEEDBACK,
+    data: { snapGrid: { kind: "resize", itemId: id, handle, group } },
+    element: elRef,
+  });
+
+  return {
+    setRef: (el: RefTarget) => {
+      elRef.value = toElement(el);
+    },
+    handleProps: { [RESIZE_HANDLE_ATTR]: true },
+    isResizing: computed(() => {
+      tick();
+      return controller.resizeSnapshot(id).isResizing;
+    }),
+  };
+}

--- a/packages/grid-vue/src/hooks/useResponsiveLayout.ts
+++ b/packages/grid-vue/src/hooks/useResponsiveLayout.ts
@@ -1,0 +1,105 @@
+import {
+  type BreakpointCols,
+  type Breakpoints,
+  type Compactor,
+  type Layout,
+  type ResponsiveLayouts,
+  findOrGenerateResponsiveLayout,
+  getBreakpointFromWidth,
+  getColsFromBreakpoint,
+  verticalCompactor,
+} from "@snapgridjs/core";
+import { type ComputedRef, computed, watch } from "vue";
+
+/** react-grid-layout's default breakpoints (px) and column counts. */
+export const DEFAULT_BREAKPOINTS: Breakpoints = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 };
+export const DEFAULT_BREAKPOINT_COLS: BreakpointCols = { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 };
+
+export interface UseResponsiveLayoutOptions {
+  /** Current container width in pixels. */
+  width: number;
+  /** Controlled per-breakpoint layouts. Missing breakpoints are generated from the nearest one. */
+  layouts: ResponsiveLayouts;
+  /** Breakpoint → min width (px). @default lg/md/sm/xs/xxs */
+  breakpoints?: Breakpoints;
+  /** Breakpoint → column count. @default 12/10/6/4/2 */
+  cols?: BreakpointCols;
+  /** Compaction strategy used when generating a missing breakpoint's layout. */
+  compactor?: Compactor;
+  /** Called when a layout commits: the active layout and the updated map. */
+  onLayoutChange?: (layout: Layout, layouts: ResponsiveLayouts) => void;
+  /** Called when the active breakpoint changes. */
+  onBreakpointChange?: (breakpoint: string, cols: number) => void;
+}
+
+export interface ResponsiveLayoutHandle {
+  /** The active breakpoint name. */
+  breakpoint: ComputedRef<string>;
+  /** Column count for the active breakpoint. */
+  cols: ComputedRef<number>;
+  /** The resolved layout for the active breakpoint (generated if absent). */
+  layout: ComputedRef<Layout>;
+  /** Pass to the grid's `onLayoutChange`; updates the active breakpoint's layout. */
+  onLayoutChange: (layout: Layout) => void;
+}
+
+/**
+ * Headless responsive layout engine: resolves the active breakpoint and its column
+ * count/layout from the container width, generating a layout for the active breakpoint
+ * from the nearest one when missing. `getOptions` is a getter so the result tracks the
+ * consumer's live width/layouts.
+ */
+export function useResponsiveLayout(
+  getOptions: () => UseResponsiveLayoutOptions,
+): ResponsiveLayoutHandle {
+  // Resolve everything in one computed so the pieces stay consistent and there are no
+  // cross-computed references. The fallback source for generating a missing breakpoint
+  // is the widest provided layout, so generation is a pure function of inputs
+  // (independent of visit order).
+  const resolved = computed(() => {
+    const o = getOptions();
+    const breakpoints = o.breakpoints ?? DEFAULT_BREAKPOINTS;
+    const compactor = o.compactor ?? verticalCompactor;
+    const breakpoint = getBreakpointFromWidth(breakpoints, o.width);
+    const cols = getColsFromBreakpoint(breakpoint, o.cols ?? DEFAULT_BREAKPOINT_COLS);
+    let source = breakpoint;
+    let sourceWidth = Number.NEGATIVE_INFINITY;
+    for (const [bp, minWidth] of Object.entries(breakpoints)) {
+      if (o.layouts[bp] && minWidth > sourceWidth) {
+        sourceWidth = minWidth;
+        source = bp;
+      }
+    }
+    const layout = findOrGenerateResponsiveLayout(
+      o.layouts,
+      breakpoints,
+      breakpoint,
+      source,
+      cols,
+      compactor,
+    );
+    return { breakpoint, cols, layout };
+  });
+
+  // Fire onBreakpointChange when the active breakpoint actually changes. A non-immediate
+  // `watch` gives the "not on mount" rule for free (the Svelte binding needs an explicit
+  // sentinel for this).
+  watch(
+    () => resolved.value.breakpoint,
+    (bp) => {
+      getOptions().onBreakpointChange?.(bp, resolved.value.cols);
+    },
+  );
+
+  const onLayoutChange = (next: Layout): void => {
+    const o = getOptions();
+    o.onLayoutChange?.(next, { ...o.layouts, [resolved.value.breakpoint]: next });
+  };
+
+  return {
+    breakpoint: computed(() => resolved.value.breakpoint),
+    cols: computed(() => resolved.value.cols),
+    layout: computed(() => resolved.value.layout),
+    onLayoutChange,
+  };
+}

--- a/packages/grid-vue/src/index.ts
+++ b/packages/grid-vue/src/index.ts
@@ -1,0 +1,112 @@
+/**
+ * @snapgridjs/vue
+ *
+ * A react-grid-layout v2 alternative built on dnd-kit, for Vue 3.
+ *
+ * Two layers:
+ *  - Headless: `useGridContainer` + `useGridItem` / `useGridPlaceholder`, composed
+ *    under a dnd-kit `DragDropProvider` you supply. You render your own markup; the
+ *    composables return function refs, positioning styles, and drag state.
+ *  - Components: `GridLayout` / `GridItem` / `GridPlaceholder` — a thin, drop-in shell
+ *    over the composables for the common case.
+ *
+ * The layout math, compaction, and drag session live in `@snapgridjs/core` +
+ * `@snapgridjs/dnd` (framework-free) — this package is the Vue binding, mirroring
+ * `@snapgridjs/react` and `@snapgridjs/svelte`.
+ *
+ * NB: Vue resolves `inject` from the parent chain, so every composable here must be
+ * called in a CHILD component of the `<DragDropProvider>`, never in the component that
+ * renders it.
+ */
+
+// Headless layer. `useGridContainer` is the grid host (creates the controller + drag
+// engine); tiles resolve it by `group` (= the grid's id).
+export { useGridContainer } from "./hooks/useGridContainer.js";
+export type { GridContainerResult } from "./hooks/useGridContainer.js";
+export { useGridController } from "./hooks/useGridController.js";
+export type { UseGridControllerOptions } from "./hooks/useGridController.js";
+export { useGridItem } from "./hooks/useGridItem.js";
+export type { GridItemHandle, UseGridItemOptions } from "./hooks/useGridItem.js";
+export { useGridPlaceholder } from "./hooks/useGridPlaceholder.js";
+export type { GridPlaceholderInfo } from "./hooks/useGridPlaceholder.js";
+export { useGridResizeHandle } from "./hooks/useGridResizeHandle.js";
+export type { GridResizeHandle, UseGridResizeHandleOptions } from "./hooks/useGridResizeHandle.js";
+export { resolveController } from "./hooks/resolveController.js";
+
+export {
+  DEFAULT_BREAKPOINTS,
+  DEFAULT_BREAKPOINT_COLS,
+  useResponsiveLayout,
+} from "./hooks/useResponsiveLayout.js";
+export type {
+  ResponsiveLayoutHandle,
+  UseResponsiveLayoutOptions,
+} from "./hooks/useResponsiveLayout.js";
+
+// Component layer
+export { GridLayout } from "./components/GridLayout.js";
+export { GridItem } from "./components/GridItem.js";
+export { GridPlaceholder } from "./components/GridPlaceholder.js";
+export { ResponsiveGridLayout } from "./components/ResponsiveGridLayout.js";
+export { SnapGridGroup } from "./components/SnapGridGroup.js";
+export type { GridLayoutProps, ResponsiveGridLayoutProps } from "./props.js";
+
+// Tiles float themselves (dnd-kit's default feedback) — snapgrid doesn't use a drag
+// overlay. The raw dnd-kit `<DragOverlay>` is re-exported for consumers who want one.
+export { DragOverlay } from "@dnd-kit/vue";
+
+// Utilities
+export { useContainerWidth } from "./hooks/useContainerWidth.js";
+export type { ContainerWidthHandle, UseContainerWidthOptions } from "./hooks/useContainerWidth.js";
+
+// Drag/drop config + event types are re-exported from the engine package, which owns
+// them (kept on the public API so `@snapgridjs/vue` stays self-sufficient).
+export type {
+  DragConfig,
+  DragSourceInfo,
+  DropConfig,
+  GridDropData,
+  GridEventCallback,
+  ResizeConfig,
+} from "@snapgridjs/dnd";
+// `snapMove` — interop reducer: drag a sortable card INTO a grid (lands at a real cell,
+// with compaction). Its drag-OUT counterpart is `removeItemWithCompactor`.
+export { snapMove } from "@snapgridjs/dnd";
+export type { SnapMoveContext, SnapMoveEvent } from "@snapgridjs/dnd";
+
+// Re-export the layout-engine surface so consumers can build compactors, inspect types,
+// and use geometry helpers without a separate import.
+export type {
+  BreakpointCols,
+  Breakpoints,
+  Compactor,
+  CompactType,
+  GridConfig,
+  Layout,
+  LayoutItem,
+  PositionParams,
+  ResizeHandleAxis,
+  ResponsiveLayouts,
+} from "@snapgridjs/core";
+export {
+  defaultGridConfig,
+  getCompactor,
+  horizontalCompactor,
+  insertItemWithCompactor,
+  noCompactor,
+  removeItemWithCompactor,
+  toPositionParams,
+  verticalCompactor,
+} from "@snapgridjs/core";
+
+// Re-export the dnd-kit primitives needed to build your own draggables for a grid (e.g.
+// an external-drop palette) or supply your own provider. Import these from
+// `@snapgridjs/vue` rather than directly from `@dnd-kit/*` so they share snapgrid's
+// single dnd-kit instance — a second copy of `@dnd-kit/vue` is a separate
+// DragDropProvider context, and drags from it never reach the grid.
+export { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/vue";
+export { Feedback, KeyboardSensor, PointerSensor } from "@dnd-kit/dom";
+// Nest a non-grid drop zone inside a grid: pass `nestedDropCollisionDetector` to your
+// `useDroppable` and mark the element with `SNAPGRID_DROPPABLE_ATTR`, so the zone
+// outranks the grid it sits in (innermost-wins). See the nesting guide.
+export { SNAPGRID_DROPPABLE_ATTR, nestedDropCollisionDetector } from "@snapgridjs/dnd";

--- a/packages/grid-vue/src/props.ts
+++ b/packages/grid-vue/src/props.ts
@@ -1,0 +1,100 @@
+import type {
+  BreakpointCols,
+  Breakpoints,
+  Compactor,
+  GridConfig,
+  Layout,
+  LayoutItem,
+  ResponsiveLayouts,
+} from "@snapgridjs/core";
+import type { DragConfig, DragSourceInfo, DropConfig, GridEventCallback } from "@snapgridjs/dnd";
+import type { PropType } from "vue";
+import type { UseGridControllerOptions } from "./hooks/useGridController.js";
+
+/**
+ * Props for {@link GridLayout} / the internal grid surface.
+ *
+ * Item content is supplied through the `item` scoped slot (Vue has no keyed-children
+ * analog to React's `Children.map`): `<template #item="{ item }">`. The slot receives the
+ * **committed** layout entry — the one you passed in `layout`, not the reflowed preview.
+ * A tile's live (reflowed) entry during a drag is available from `useGridItem().item`.
+ * `class` and `style` are ordinary fallthrough attributes and merge onto the surface.
+ */
+export interface GridLayoutProps extends UseGridControllerOptions {}
+
+/** Props for {@link ResponsiveGridLayout}. */
+export interface ResponsiveGridLayoutProps {
+  /** Container width in pixels (e.g. from {@link useContainerWidth}). */
+  width: number;
+  /** Controlled per-breakpoint layouts. Items are keyed by `i`. */
+  layouts: ResponsiveLayouts;
+  /** Called when a layout commits: the active layout and the updated map. */
+  onLayoutChange?: (layout: Layout, layouts: ResponsiveLayouts) => void;
+  /** Called when the active breakpoint changes. */
+  onBreakpointChange?: (breakpoint: string, cols: number) => void;
+  /** Breakpoint → min width (px). @default lg/md/sm/xs/xxs */
+  breakpoints?: Breakpoints;
+  /** Breakpoint → column count. @default 12/10/6/4/2 */
+  cols?: BreakpointCols;
+  rowHeight?: number;
+  margin?: [number, number];
+  containerPadding?: [number, number] | null;
+  compactor?: Compactor;
+  dragConfig?: DragConfig;
+  resizeConfig?: ResizeConfig;
+  isDraggable?: boolean;
+  isResizable?: boolean;
+  autoSize?: boolean;
+}
+
+// Re-exported for the interface above without pulling the value import in.
+type ResizeConfig = import("@snapgridjs/dnd").ResizeConfig;
+
+// Optional booleans MUST carry an explicit `default: undefined`. Vue casts an absent
+// Boolean prop to `false` unless a default is declared, which would turn "not
+// specified" into "explicitly disabled" and defeat the `?? true` defaults downstream.
+const optionalBoolean = { type: Boolean, default: undefined } as const;
+
+/** Runtime prop declarations shared by `GridLayout` and the internal surface. */
+export const gridControllerProps = {
+  id: String,
+  type: String,
+  width: { type: Number, required: true as const },
+  layout: { type: Array as PropType<Layout>, required: true as const },
+  onLayoutChange: Function as PropType<(layout: Layout) => void>,
+  gridConfig: Object as PropType<Partial<GridConfig>>,
+  dragConfig: Object as PropType<DragConfig>,
+  resizeConfig: Object as PropType<ResizeConfig>,
+  dropConfig: Object as PropType<DropConfig>,
+  accept: Function as PropType<(source: DragSourceInfo) => boolean>,
+  compactor: Object as PropType<Compactor>,
+  isDraggable: optionalBoolean,
+  isResizable: optionalBoolean,
+  autoSize: optionalBoolean,
+  onDragStart: Function as PropType<GridEventCallback>,
+  onDrag: Function as PropType<GridEventCallback>,
+  onDragStop: Function as PropType<GridEventCallback>,
+  onResizeStart: Function as PropType<GridEventCallback>,
+  onResize: Function as PropType<GridEventCallback>,
+  onResizeStop: Function as PropType<GridEventCallback>,
+  onDrop: Function as PropType<(layout: Layout, item: LayoutItem, event: Event | null) => void>,
+};
+
+/** Runtime prop declarations for `ResponsiveGridLayout`. */
+export const responsiveGridProps = {
+  width: { type: Number, required: true as const },
+  layouts: { type: Object as PropType<ResponsiveLayouts>, required: true as const },
+  onLayoutChange: Function as PropType<(layout: Layout, layouts: ResponsiveLayouts) => void>,
+  onBreakpointChange: Function as PropType<(breakpoint: string, cols: number) => void>,
+  breakpoints: Object as PropType<Breakpoints>,
+  cols: Object as PropType<BreakpointCols>,
+  rowHeight: Number,
+  margin: Array as unknown as PropType<[number, number]>,
+  containerPadding: Array as unknown as PropType<[number, number] | null>,
+  compactor: Object as PropType<Compactor>,
+  dragConfig: Object as PropType<DragConfig>,
+  resizeConfig: Object as PropType<ResizeConfig>,
+  isDraggable: optionalBoolean,
+  isResizable: optionalBoolean,
+  autoSize: optionalBoolean,
+};

--- a/packages/grid-vue/src/reactivity.ts
+++ b/packages/grid-vue/src/reactivity.ts
@@ -1,0 +1,30 @@
+import type { GridController } from "@snapgridjs/dnd";
+import { onScopeDispose, shallowRef } from "vue";
+
+/**
+ * Bridge {@link GridController.subscribe} (a plain observable — the React binding
+ * consumes it via `useSyncExternalStore`) into Vue reactivity. Returns a getter that,
+ * when read inside a `computed`/`watch`, re-runs on every controller emit (i.e.
+ * drag-state changes: `setSession` / `setKeyboard`). Combine it with the container's
+ * `version` tick (config/committed republish) to cover all the inputs a tile's
+ * rendered position depends on.
+ *
+ * Unlike the Svelte binding — which subscribes inside an `$effect`, so the first
+ * paint precedes the subscription — this subscribes eagerly during setup, closing
+ * that gap. Cleanup rides the component's effect scope.
+ *
+ * Must be called during component setup (it registers a scope-disposal hook).
+ */
+export function controllerTick(controller: GridController): () => number {
+  const tick = shallowRef(0);
+  // Assign from a plain counter rather than `tick.value++`: a read-modify-write would
+  // track `tick` as a dependency if a notification ever landed inside a tracked
+  // effect. A bare write only triggers.
+  let count = 0;
+  onScopeDispose(
+    controller.subscribe(() => {
+      tick.value = ++count;
+    }),
+  );
+  return () => tick.value;
+}

--- a/packages/grid-vue/src/reflow.ts
+++ b/packages/grid-vue/src/reflow.ts
@@ -1,0 +1,12 @@
+// Shared reflow timing for tiles and the placeholder, so they animate in lockstep
+// when a drag reflows the grid. Used by useGridItem (the tile's WAAPI reflow FLIP
+// and its out-of-drag CSS transition) and GridPlaceholder (its default look).
+// Mirrors @snapgridjs/react's reflow.ts — the values are framework-free.
+export const REFLOW_MS = 150;
+export const REFLOW_EASING = "ease";
+// The placeholder is transform-positioned; this transitions its motion.
+export const REFLOW_TRANSITION = `transform ${REFLOW_MS}ms ${REFLOW_EASING}, width ${REFLOW_MS}ms ${REFLOW_EASING}, height ${REFLOW_MS}ms ${REFLOW_EASING}`;
+// Tiles rest on left/top and animate POSITION via the compositor FLIP in useGridItem,
+// so their CSS transition covers SIZE only: a left/top transition would be copied onto
+// dnd-kit's float clone and fly it in from (0,0) at lift.
+export const TILE_TRANSITION = `width ${REFLOW_MS}ms ${REFLOW_EASING}, height ${REFLOW_MS}ms ${REFLOW_EASING}`;

--- a/packages/grid-vue/tsconfig.json
+++ b/packages/grid-vue/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    // Components are authored as `defineComponent` + `h()` render functions (no SFCs),
+    // so the repo-wide `react-jsx` transform must not apply to this package's sources.
+    "jsx": "preserve",
+    // Typecheck against the live core + engine source (mirrors the React package),
+    // so cross-package type errors surface without a prior build.
+    "paths": {
+      "@snapgridjs/core": ["../grid-core/src/index.ts"],
+      "@snapgridjs/dnd": ["../grid-dnd/src/index.ts"]
+    }
+  },
+  "include": ["src", "tsdown.config.ts", "vitest.setup.ts"]
+}

--- a/packages/grid-vue/tsdown.config.ts
+++ b/packages/grid-vue/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+// dnd-kit packages, vue (peer) and @snapgridjs/core + /dnd are all declared
+// dependencies, so tsdown externalizes them automatically. Components are plain
+// `defineComponent` render functions, so no SFC toolchain is involved.
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  treeshake: true,
+});

--- a/packages/grid-vue/vitest.setup.ts
+++ b/packages/grid-vue/vitest.setup.ts
@@ -1,0 +1,14 @@
+import { cleanup } from "@testing-library/vue";
+import { afterEach } from "vitest";
+
+// Unmount rendered trees between tests (globals are not enabled).
+afterEach(cleanup);
+
+// jsdom lacks ResizeObserver; provide a minimal stub for useContainerWidth.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  } as unknown as typeof ResizeObserver;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.2.6
         version: 5.4.2(svelte@5.56.6)(vite@5.4.21(@types/node@22.19.19)(lightningcss@1.32.0))(vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0))
+      '@testing-library/vue':
+        specifier: ^8.1.0
+        version: 8.1.0(@vue/compiler-dom@3.5.40)(@vue/compiler-sfc@3.5.40)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@5.9.3))
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.19
@@ -75,6 +78,9 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.40(typescript@5.9.3)
 
   apps/docs:
     dependencies:
@@ -156,7 +162,7 @@ importers:
         version: 3.2.4(svelte@5.56.6)
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.5(postcss@8.5.15)(svelte@5.56.6)(typescript@5.9.3)
+        version: 6.0.5(postcss@8.5.25)(svelte@5.56.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -263,6 +269,34 @@ importers:
         specifier: ^4.1.4
         version: 4.7.3(picomatch@4.0.4)(svelte@5.56.6)(typescript@5.9.3)
 
+  packages/grid-vue:
+    dependencies:
+      '@snapgridjs/core':
+        specifier: workspace:*
+        version: link:../grid-core
+      '@snapgridjs/dnd':
+        specifier: workspace:*
+        version: link:../grid-dnd
+    devDependencies:
+      '@dnd-kit/abstract':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/collision':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/dom':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/state':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/vue':
+        specifier: ^0.4.0
+        version: 0.4.0(vue@3.5.40(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.40(typescript@5.9.3)
+
 packages:
 
   '@antfu/install-pkg@1.1.0':
@@ -278,6 +312,10 @@ packages:
   '@babel/generator@8.0.0-rc.5':
     resolution: {integrity: sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@8.0.0-rc.6':
     resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
@@ -295,6 +333,11 @@ packages:
     resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@8.0.0-rc.4':
     resolution: {integrity: sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -307,6 +350,10 @@ packages:
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0-rc.6':
@@ -683,6 +730,11 @@ packages:
     resolution: {integrity: sha512-hWmIenZ7EeMh8eDrNteL+5yIDgUg/0GnF+U80Pr0nScWGHdCTehYKXEGQtV2PNm99ta5qNg6GuvvtP4WRS8dug==}
     peerDependencies:
       svelte: ^5.29.0
+
+  '@dnd-kit/vue@0.4.0':
+    resolution: {integrity: sha512-+8g6D8bG/+xTxrMV78nxw2F5/spir8X7IiGv5eNtKjE12lEr7EmSCcoTzQSJjvYvviK1fVHd/dTKi3A061Zlhg==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1195,6 +1247,10 @@ packages:
   '@internationalized/string@3.2.9':
     resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1396,6 +1452,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -1433,6 +1492,10 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -1798,6 +1861,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -1830,6 +1897,16 @@ packages:
       vite:
         optional: true
       vitest:
+        optional: true
+
+  '@testing-library/vue@8.1.0':
+    resolution: {integrity: sha512-ls4RiHO1ta4mxqqajWRh8158uFObVrrtAPoxk7cIp4HrnQUj/ScKzqz53HxYpG3X6Zb7H2v+0eTGLSoy8HQ2nA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@vue/compiler-sfc': '>= 3'
+      vue: '>= 3'
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
         optional: true
 
   '@theguild/remark-mermaid@0.3.0':
@@ -2044,9 +2121,50 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/reactivity@3.5.40':
+    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+
+  '@vue/runtime-core@3.5.40':
+    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+
+  '@vue/runtime-dom@3.5.40':
+    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
+
+  '@vue/server-renderer@3.5.40':
+    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vue/test-utils@2.4.11':
+    resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2070,9 +2188,21 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansis@4.3.0:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
@@ -2091,11 +2221,18 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
   array-iterate@2.0.1:
@@ -2120,12 +2257,19 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2145,6 +2289,9 @@ packages:
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -2170,6 +2317,14 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -2179,6 +2334,10 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2228,12 +2387,23 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -2249,6 +2419,9 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -2452,9 +2625,21 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -2507,8 +2692,22 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -2526,6 +2725,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2533,6 +2736,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -2609,6 +2815,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2656,6 +2865,14 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -2685,6 +2902,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2708,6 +2928,11 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -2721,6 +2946,17 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -2824,8 +3060,15 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -2840,6 +3083,30 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
@@ -2852,6 +3119,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -2863,6 +3134,14 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2878,13 +3157,41 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -2898,8 +3205,22 @@ packages:
     resolution: {integrity: sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==}
     engines: {node: '>=18'}
 
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3289,6 +3610,14 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
@@ -3301,6 +3630,11 @@ packages:
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3357,6 +3691,11 @@ packages:
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3371,6 +3710,22 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3411,6 +3766,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -3450,6 +3808,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3496,12 +3858,20 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
@@ -3518,6 +3888,9 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3630,6 +4003,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
@@ -3754,6 +4131,10 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -3778,6 +4159,14 @@ packages:
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3795,6 +4184,22 @@ packages:
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3848,12 +4253,28 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3884,6 +4305,10 @@ packages:
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   svelte-check@4.7.3:
     resolution: {integrity: sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg==}
@@ -4227,6 +4652,17 @@ packages:
       jsdom:
         optional: true
 
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+
+  vue@3.5.40:
+    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -4251,6 +4687,18 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4263,6 +4711,14 @@ packages:
 
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -4345,6 +4801,8 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-string-parser@8.0.0-rc.6': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -4352,6 +4810,10 @@ snapshots:
   '@babel/helper-validator-identifier@8.0.0-rc.5': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.6': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/parser@8.0.0-rc.4':
     dependencies:
@@ -4362,6 +4824,11 @@ snapshots:
       '@babel/types': 8.0.0-rc.6
 
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@8.0.0-rc.6':
     dependencies:
@@ -4785,6 +5252,14 @@ snapshots:
       svelte: 5.56.6
       tslib: 2.8.1
 
+  '@dnd-kit/vue@0.4.0(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/dom': 0.4.0
+      '@dnd-kit/state': 0.4.0
+      tslib: 2.8.1
+      vue: 3.5.40(typescript@5.9.3)
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -5111,6 +5586,15 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5288,6 +5772,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@oxc-project/types@0.133.0': {}
 
   '@pagefind/darwin-arm64@1.5.2':
@@ -5309,6 +5795,9 @@ snapshots:
     optional: true
 
   '@pagefind/windows-x64@1.5.2':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/test@1.60.0':
@@ -5611,6 +6100,17 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -5633,6 +6133,18 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)
       vitest: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
+
+  '@testing-library/vue@8.1.0(@vue/compiler-dom@3.5.40)(@vue/compiler-sfc@3.5.40)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 9.3.4
+      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.5.40)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.40
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - '@vue/server-renderer'
 
   '@theguild/remark-mermaid@0.3.0(react@19.2.6)':
     dependencies:
@@ -5885,7 +6397,72 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/compiler-sfc@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.25
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.40':
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/reactivity@3.5.40':
+    dependencies:
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-core@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-dom@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/runtime-core': 3.5.40
+      '@vue/shared': 3.5.40
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.40':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/shared@3.5.40': {}
+
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.40)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      js-beautify: 1.15.4
+      vue: 3.5.40(typescript@5.9.3)
+      vue-component-type-helpers: 3.3.9
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.40
+
   '@xmldom/xmldom@0.9.10': {}
+
+  abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -5899,7 +6476,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   ansis@4.3.0: {}
 
@@ -5915,11 +6500,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
 
   aria-query@5.3.1: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
 
   array-iterate@2.0.1: {}
 
@@ -5937,9 +6531,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
+
+  balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -5955,6 +6555,10 @@ snapshots:
   big.js@5.2.2: {}
 
   birpc@4.0.0: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -5975,6 +6579,18 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
@@ -5986,6 +6602,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@5.6.2: {}
 
@@ -6023,11 +6644,19 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@13.1.0: {}
 
@@ -6036,6 +6665,11 @@ snapshots:
   commander@8.3.0: {}
 
   compute-scroll-into-view@3.1.1: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   cose-base@1.0.3:
     dependencies:
@@ -6263,7 +6897,40 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.3.0
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.5
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      regexp.prototype.flags: 1.5.4
+      side-channel: 1.1.1
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.22
+
   deepmerge@4.3.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   defu@6.1.7: {}
 
@@ -6304,7 +6971,20 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.8.1
+
   emoji-regex-xs@1.0.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
 
@@ -6317,9 +6997,23 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.9
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
 
   es-module-lexer@1.7.0: {}
 
@@ -6450,6 +7144,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -6503,6 +7199,15 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -6532,6 +7237,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  functions-have-names@1.2.3: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -6563,6 +7270,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -6577,6 +7293,14 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   hachure-fill@0.5.2: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -6773,7 +7497,15 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
+  ini@1.3.8: {}
+
   inline-style-parser@0.2.7: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.4
+      side-channel: 1.1.1
 
   internmap@1.0.1: {}
 
@@ -6786,11 +7518,40 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -6802,6 +7563,13 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-map@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -6812,11 +7580,42 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
   is-stream@3.0.0: {}
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-weakmap@2.0.2: {}
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
 
   is-windows@1.0.2: {}
 
@@ -6828,7 +7627,25 @@ snapshots:
     dependencies:
       system-architecture: 0.1.0
 
+  isarray@2.0.5: {}
+
   isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.8
+      nopt: 7.2.1
+
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -7506,6 +8323,12 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
+  minipass@7.1.3: {}
+
   mj-context-menu@0.6.1: {}
 
   mri@1.2.0: {}
@@ -7513,6 +8336,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
+
+  nanoid@3.3.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -7619,6 +8444,10 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -7628,6 +8457,24 @@ snapshots:
   nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
   obug@2.1.1: {}
 
@@ -7666,6 +8513,8 @@ snapshots:
   p-map@2.1.0: {}
 
   p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -7718,6 +8567,11 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -7749,6 +8603,8 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.12
@@ -7758,6 +8614,12 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7776,6 +8638,8 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  proto-list@1.2.4: {}
 
   punycode@2.3.1: {}
 
@@ -7914,6 +8778,15 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   rehype-katex@7.0.1:
     dependencies:
@@ -8152,6 +9025,12 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -8169,6 +9048,22 @@ snapshots:
   semver@7.8.1: {}
 
   server-only@0.0.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
 
   sharp@0.34.5:
     dependencies:
@@ -8230,6 +9125,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -8269,6 +9192,23 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -8277,6 +9217,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -8296,6 +9240,10 @@ snapshots:
       react: 19.2.6
 
   stylis@4.4.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   svelte-check@4.7.3(picomatch@4.0.4)(svelte@5.56.6)(typescript@5.9.3):
     dependencies:
@@ -8323,11 +9271,11 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.56.6)
 
-  svelte-preprocess@6.0.5(postcss@8.5.15)(svelte@5.56.6)(typescript@5.9.3):
+  svelte-preprocess@6.0.5(postcss@8.5.25)(svelte@5.56.6)(typescript@5.9.3):
     dependencies:
       svelte: 5.56.6
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.25
       typescript: 5.9.3
 
   svelte2tsx@0.7.58(svelte@5.56.6)(typescript@5.9.3):
@@ -8624,6 +9572,18 @@ snapshots:
       - supports-color
       - terser
 
+  vue-component-type-helpers@3.3.9: {}
+
+  vue@3.5.40(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-sfc': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/server-renderer': 3.5.40
+      '@vue/shared': 3.5.40
+    optionalDependencies:
+      typescript: 5.9.3
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -8643,6 +9603,31 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -8653,6 +9638,18 @@ snapshots:
       stackback: 0.0.2
 
   wicked-good-xpath@1.3.0: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   ws@8.21.0: {}
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -72,6 +72,40 @@ export default defineWorkspace([
     },
   },
   {
+    // Vue binding: composables/components, jsdom environment. Runs against the live
+    // core + engine source (like the React project). @dnd-kit/vue ships compiled JS and
+    // the binding authors components as `defineComponent` render functions, so no SFC
+    // compiler or dependency inlining is needed.
+    resolve: {
+      alias: { "@snapgridjs/core": coreSrc, "@snapgridjs/dnd": dndSrc },
+    },
+    test: {
+      name: "vue",
+      root: "./packages/grid-vue",
+      environment: "jsdom",
+      include: ["src/**/*.test.ts"],
+      // ssr.test.ts belongs to the `vue-ssr` project below (no DOM).
+      exclude: ["**/node_modules/**", "**/dist/**", "src/__tests__/ssr.test.ts"],
+      setupFiles: ["./vitest.setup.ts"],
+    },
+  },
+  {
+    // Server rendering must be exercised with NO DOM at all: under jsdom, `document` and
+    // `window` exist, so a "doesn't touch the DOM on the server" assertion is
+    // unenforceable and a real Nuxt SSR regression would still pass. No setup file —
+    // that one pulls in @testing-library/vue and a ResizeObserver stub, both of which
+    // would defeat the point.
+    resolve: {
+      alias: { "@snapgridjs/core": coreSrc, "@snapgridjs/dnd": dndSrc },
+    },
+    test: {
+      name: "vue-ssr",
+      root: "./packages/grid-vue",
+      environment: "node",
+      include: ["src/__tests__/ssr.test.ts"],
+    },
+  },
+  {
     // Docs app: data-level guards for the showcase (layout validity, registry).
     test: {
       name: "docs",


### PR DESCRIPTION
## What & why

snapgrid ships React and Svelte bindings over a framework-free engine (`@snapgridjs/core` + `@snapgridjs/dnd`). This adds the third binding, **`@snapgridjs/vue`**, built on the official [`@dnd-kit/vue@0.4.0`](https://www.npmjs.com/package/@dnd-kit/vue) — the same dnd-kit line the other bindings already pin, so no engine, peer or lockfile bump is needed. The core and engine packages are reused **unchanged**.

The port follows **`@snapgridjs/svelte`, not `@snapgridjs/react`**. React's binding leans on a prop change re-rendering the whole subtree and on `useSyncExternalStore`; Vue has neither, so it needs the same two-signal design Svelte introduced — the controller emits only on drag state (`setSession`/`setKeyboard`), and a separate `version` tick covers `setConfig`/`setCommitted` republishes.

Public API mirrors React's naming: `useGridContainer`, `useGridItem`, `useGridController`, `useGridPlaceholder`, `useGridResizeHandle`, `useResponsiveLayout`, `useContainerWidth`, `resolveController`, plus `GridLayout`, `ResponsiveGridLayout`, `GridItem`, `GridPlaceholder`, `SnapGridGroup`. Feature parity with the other bindings: cross-grid and nested dragging, keyboard a11y, resize handles, external drop, static/pinned items, pluggable packing, responsive breakpoints.

Components are authored as `defineComponent` + `h()` render functions (as `@dnd-kit/vue` itself is), so the package builds with **tsdown like `grid-react`** and needs no SFC toolchain to build or consume.

## Vue-specific notes

Three behaviours that shaped the implementation and are worth knowing when reviewing:

- **`toValue()` invokes a bare function as a getter.** Every `@dnd-kit/vue` input is `MaybeRefOrGetter` and resolved with `toValue`, so an input whose *value* is a function — `accept`, `collisionDetector`, the `plugins` callback — would be **called** instead of assigned. These are wrapped as `() => fn`.
- **dnd-kit's `useInstance` is not used for `GridController`.** It passes `register()`'s return to `onWatcherCleanup`, and `GridController.register` is a deliberate no-op returning `undefined`, which makes Vue log an "Invalid value type passed to callWithAsyncErrorHandling" warning on every teardown. The controller is constructed directly; the helper does nothing else that is needed.
- **Vue resolves `inject` from the parent chain**, so composables must run in a *child* of `<DragDropProvider>` — hence `GridSurface` as its own component, and a container that never injects back the context it provides.

A function ref is also re-invoked on **every patch**, not only when the element changes, so element side effects are keyed to identity via `watch` rather than done inline in the ref.

## Tests

26 tests in two projects, all green (`pnpm validate` passes: typecheck, lint, test, build, size).

- `grid` / `dragLifecycle` / `responsive` mirror the Svelte suites — geometry, reactive reflow on layout/width change, auto-height, nested + sibling provider dedupe, headless composition, the full drag/resize/keyboard/external-drop event contract, and cross-grid hand-off.
- `ssr` runs in a **separate `vue-ssr` project under `environment: "node"`** — with no DOM globals at all, so the "server render must not touch the DOM" contract is actually enforced rather than silently satisfied by jsdom.
- `regressions` covers two bugs caught in review: `useContainerWidth` rebuilding its `ResizeObserver` on every render, and an `id` fallthrough attribute on `ResponsiveGridLayout` hijacking the grid's registry key. Both were verified to fail before the fix.

Size: 8.62 kB brotli (budget 9 kB), comparable to the React binding's own code.

## Not included

**Docs.** The `apps/docs` Vue site, demos and MDX land in a follow-up, matching the Svelte rollout (#39 binding, then #45 docs). Root `README.md` and `roadmap.mdx` are deliberately unchanged until then — they should not advertise Vue as shipped before the guides exist. The package README says the Vue guides are in progress and points at the React/Svelte guides, which describe the same engine.

`RELEASING.md` **is** updated here, because adding the package to the changesets `fixed` array in this PR made its "five packages / lockstep" section wrong.

## Release note

`@snapgridjs/vue` needs a **manual first publish with 2FA** before CI/OIDC can take it over — see RELEASING.md → "Adding a NEW package". Suggested order: merge this, land the docs PR, then cut one coordinated release, so the package never sits on npm without documentation.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] `pnpm validate` passes (typecheck, lint, test, build)
- [x] Added/updated tests for the change
- [ ] Updated docs (`apps/docs`) if behaviour or API changed — follow-up PR, see above
- [x] Noted any breaking changes below

## Breaking changes

None. New package; existing packages are untouched apart from joining the changesets lockstep set, which moves the published set from five to six.
